### PR TITLE
fix(makefile): Remove deprecated variables and legacy targets

### DIFF
--- a/.claude/skills/learned/breaking-changes-over-deprecation/SKILL.md
+++ b/.claude/skills/learned/breaking-changes-over-deprecation/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: breaking-changes-over-deprecation
+description: "When refactoring personal/local projects, prefer complete removal over deprecation to reduce maintenance burden"
+---
+
+# Breaking Changes Over Deprecation
+
+## Problem
+
+When cleaning up code, the default approach is to maintain backward compatibility:
+- Add [DEPRECATED] comments
+- Keep legacy aliases
+- Maintain old targets/functions
+
+This creates ongoing maintenance burden for no benefit in personal/local projects.
+
+## Solution
+
+For personal/local projects, prefer breaking changes:
+
+1. **Remove completely** instead of deprecating
+2. **Delete legacy targets** instead of hiding from help
+3. **Remove unused variables** instead of commenting out
+4. **Update documentation** to reflect removals
+
+## When to Use
+
+- Personal or local-only projects
+- Active development (not abandoned codebase)
+- Clear ownership (no external consumers)
+- Issue/PR documents the breaking changes
+
+## When NOT to Use
+
+- Public libraries with external users
+- Shared infrastructure
+- APIs consumed by other teams

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ VIDEO ?= $(shell $(call CFG,video))
 OUTPUT ?= $(shell $(call CFG,output))
 INTERVAL ?= $(shell $(call CFG,interval))
 THRESHOLD ?= $(shell $(call CFG,threshold))
-OCR_TIMEOUT ?= $(shell $(call CFG,ocr_timeout))
 
 # Hash directory (set manually for individual targets)
 # Usage: make ocr HASHDIR=output/a3f8c2d1e5b7f9c0
@@ -25,8 +24,9 @@ LIMIT_OPT := $(if $(LIMIT),--limit $(LIMIT),)
 # Book converter variables
 INPUT_MD ?=
 OUTPUT_XML ?=
+USE_LLM ?= $(shell $(call CFG,use_llm_toc_classifier))
 
-.PHONY: help setup run extract-frames deduplicate split-spreads detect-layout run-ocr consolidate build-book preview-extract preview-trim preview-trim-grid test test-book-converter test-cov converter convert-sample ruff pylint lint clean clean-all
+.PHONY: help setup run extract-frames deduplicate split-spreads detect-layout run-ocr consolidate preview-extract preview-trim preview-trim-grid test test-book-converter test-cov converter convert-sample ruff pylint lint clean clean-all
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -58,7 +58,6 @@ SPREAD_RIGHT_PAGE_INNER ?= $(shell $(call CFG,spread_right_page_inner))
 SPREAD_RIGHT_PAGE_OUTER ?= $(shell $(call CFG,spread_right_trim))
 
 # Global trim
-ASPECT_RATIO ?= $(shell $(call CFG,spread_aspect_ratio))
 GLOBAL_TRIM_TOP ?= $(shell $(call CFG,global_trim_top))
 GLOBAL_TRIM_BOTTOM ?= $(shell $(call CFG,global_trim_bottom))
 GLOBAL_TRIM_LEFT ?= $(shell $(call CFG,global_trim_left))
@@ -72,7 +71,6 @@ split-spreads: setup ## Step 2.5: Split spread images into pages (requires HASHD
 		--left-page-inner $(SPREAD_LEFT_PAGE_INNER) \
 		--right-page-inner $(SPREAD_RIGHT_PAGE_INNER) \
 		--right-page-outer $(SPREAD_RIGHT_PAGE_OUTER) \
-		--aspect-ratio $(ASPECT_RATIO) \
 		--global-trim-top $(GLOBAL_TRIM_TOP) \
 		--global-trim-bottom $(GLOBAL_TRIM_BOTTOM) \
 		--global-trim-left $(GLOBAL_TRIM_LEFT) \
@@ -155,31 +153,12 @@ run: setup ## Run full pipeline for a video (VIDEO required, OUTPUT/LIMIT option
 	@$(MAKE) --no-print-directory converter INPUT_MD="$(HASHDIR)/book.md" OUTPUT_XML="$(HASHDIR)/book.xml"
 	@echo "=== Done: $(HASHDIR)/book.xml ==="
 
-# === Legacy Targets (for backward compatibility) ===
-
-yomitoku-detect: setup ## [LEGACY] Run yomitoku layout detection (use detect-layout instead)
-	@test -n "$(HASHDIR)" || { echo "Error: HASHDIR required. Usage: make yomitoku-detect HASHDIR=output/<hash>"; exit 1; }
-	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.cli.detect_layout "$(HASHDIR)/pages" -o "$(HASHDIR)/layout" --device cpu
-
-rover-ocr: setup ## [LEGACY] Run ROVER OCR (use run-ocr instead)
-	@test -n "$(HASHDIR)" || { echo "Error: HASHDIR required. Usage: make rover-ocr HASHDIR=output/<hash>"; exit 1; }
-	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.cli.run_ocr "$(HASHDIR)/pages" -o "$(HASHDIR)/ocr_output" --device cpu
-
-build-book: setup ## [LEGACY] Build book.txt from ROVER outputs (use consolidate instead)
-	@test -n "$(HASHDIR)" || { echo "Error: HASHDIR required. Usage: make build-book HASHDIR=output/<hash>"; exit 1; }
-	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.cli.consolidate "$(HASHDIR)/ocr_output" -o "$(HASHDIR)"
-
-# === Quick Test (deprecated alias) ===
-
-test-run: ## Quick test with LIMIT=25 default (Usage: make test-run VIDEO=input.mov)
-	@$(MAKE) --no-print-directory run VIDEO="$(VIDEO)" LIMIT="$(or $(LIMIT),25)"
-
 # === Book Converter ===
 
 converter: setup ## Convert book.md to XML (Usage: make converter INPUT_MD=path/to/book.md OUTPUT_XML=path/to/book.xml [THRESHOLD=0.5] [VERBOSE=1])
 	@test -n "$(INPUT_MD)" || { echo "Error: INPUT_MD required. Usage: make converter INPUT_MD=input.md OUTPUT_XML=output.xml"; exit 1; }
 	@test -n "$(OUTPUT_XML)" || { echo "Error: OUTPUT_XML required. Usage: make converter INPUT_MD=input.md OUTPUT_XML=output.xml"; exit 1; }
-	PYTHONPATH=$(CURDIR) USE_LLM_TOC_CLASSIFIER=true $(PYTHON) -m src.book_converter.cli "$(INPUT_MD)" "$(OUTPUT_XML)" --group-pages \
+	PYTHONPATH=$(CURDIR) $(if $(USE_LLM),USE_LLM_TOC_CLASSIFIER=$(USE_LLM)) $(PYTHON) -m src.book_converter.cli "$(INPUT_MD)" "$(OUTPUT_XML)" --group-pages \
 		$(if $(THRESHOLD),--running-head-threshold $(THRESHOLD)) \
 		$(if $(VERBOSE),--verbose)
 

--- a/specs/quick/004-032-makefile-naming-fix/plan.md
+++ b/specs/quick/004-032-makefile-naming-fix/plan.md
@@ -1,0 +1,70 @@
+---
+status: completed
+created: 2026-03-01
+branch: quick/004-032-makefile-naming-fix
+issue: 32
+---
+
+# 032-makefile-naming-fix
+
+## 概要
+
+Makefile の命名不整合と設定問題を修正。後方互換性は全て削除。
+
+## ゴール
+
+- [x] 非推奨変数・引数を完全削除
+- [x] USE_LLM_TOC_CLASSIFIER を設定可能に
+- [x] Legacy targets を完全削除
+
+## スコープ外
+
+- trim 変数命名（#34 で対応済み）
+- 変数グループ化（別 Issue で対応）
+
+## 前提条件
+
+- 後方互換性は考慮しない（破壊的変更OK）
+
+---
+
+## 実装タスク
+
+### Phase 1: 非推奨変数・引数の削除
+
+- [x] T001 [Makefile] ASPECT_RATIO 変数定義を削除（L61）
+- [x] T002 [Makefile] split-spreads から --aspect-ratio 引数削除（L75）
+- [x] T003 [Makefile] OCR_TIMEOUT 変数定義を削除（L14）
+
+### Phase 2: 設定の改善
+
+- [x] T004 [Makefile] USE_LLM 変数を追加し converter ターゲットで使用（L182）
+
+### Phase 3: Legacy/非推奨ターゲット削除
+
+- [x] T005 [Makefile] test-run ターゲットを削除（L174-175）
+- [x] T006 [Makefile] yomitoku-detect ターゲットを削除（L160-162）
+- [x] T007 [Makefile] rover-ocr ターゲットを削除（L164-166）
+- [x] T008 [Makefile] build-book ターゲットを削除（L168-170）
+- [x] T009 [Makefile] Legacy セクションコメントを削除（L158-159）
+
+### Phase 4: 確認
+
+- [x] T010 `make help` でヘルプ表示確認
+- [x] T011 `make lint` 通過確認
+
+---
+
+## リスク
+
+| レベル | 内容 |
+|-------|------|
+| MEDIUM | Legacy targets 削除で古いスクリプト/ドキュメントが壊れる → Issue で告知済み |
+
+---
+
+## 完了条件
+
+- [x] 全タスク完了
+- [x] make help 正常動作
+- [x] make lint 通過


### PR DESCRIPTION
## Summary

- Remove `ASPECT_RATIO` variable (deprecated, unused since spread_mode implementation)
- Remove `OCR_TIMEOUT` variable (defined but never used)
- Remove `--aspect-ratio` argument from split-spreads target
- Add `USE_LLM` variable for converter target configurability (replaces hardcoded `USE_LLM_TOC_CLASSIFIER=true`)
- Remove legacy targets: `test-run`, `yomitoku-detect`, `rover-ocr`, `build-book`
- Clean up `.PHONY` declarations

## Breaking Changes

Legacy targets removed. Use modern equivalents:
| Removed | Use Instead |
|---------|-------------|
| `test-run` | `make run LIMIT=25` |
| `yomitoku-detect` | `make detect-layout` |
| `rover-ocr` | `make run-ocr` |
| `build-book` | `make consolidate` |

## Test plan

- [x] `make help` shows updated targets
- [x] `make lint` passes

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)