### PR TITLE
fix: page_grouper が末尾ゼロ番号体系に対応 (#40)

### DIFF
--- a/src/book_converter/page_grouper/hierarchy.py
+++ b/src/book_converter/page_grouper/hierarchy.py
@@ -19,6 +19,31 @@ from .models import FlattenStats, TOCEntry
 from .section import is_chapter_title_page, normalize_for_matching, parse_section_number
 
 
+def _find_toc_key(number: str, toc_lookup: dict) -> str | None:
+    """Find the actual TOC key for a section number.
+
+    Handles both standard (1, 1.1) and zero-padded (1.0.0, 1.1.0) formats.
+
+    Args:
+        number: Section number to look up (e.g., "1", "1.1")
+        toc_lookup: Dict mapping section number to any TOC entry type
+
+    Returns:
+        The actual key in toc_lookup, or None
+    """
+    if number in toc_lookup:
+        return number
+
+    # Try appending .0 suffixes: "1" -> "1.0" -> "1.0.0"
+    padded = number
+    for _ in range(3):
+        padded = f"{padded}.0"
+        if padded in toc_lookup:
+            return padded
+
+    return None
+
+
 def _find_first_chapter(toc_lookup: dict[str, TOCEntry]) -> str | None:
     """Find the first chapter in TOC.
 
@@ -28,22 +53,30 @@ def _find_first_chapter(toc_lookup: dict[str, TOCEntry]) -> str | None:
     Returns:
         First chapter number or None if no chapters exist
     """
-    # Find all chapter entries (level=1) with valid numeric section numbers
-    chapter_numbers = [num for num, entry in toc_lookup.items() if entry.level == 1 and num and num.isdigit()]
+    # Find all chapter entries using SectionNumber-based detection
+    chapter_entries = []
+    for num in toc_lookup:
+        sn = parse_section_number(num)
+        if sn and sn.is_chapter:
+            chapter_entries.append((sn.chapter_num, num))
 
-    if not chapter_numbers:
+    if not chapter_entries:
         return None
 
     # Return the numerically smallest chapter number
-    return min(chapter_numbers, key=lambda x: int(x))
+    return min(chapter_entries, key=lambda x: x[0])[1]
 
 
 def _find_first_chapter_entry(toc_lookup: dict[str, TocEntry]) -> str | None:
     """Find the first chapter number in TOC."""
-    chapter_numbers = [num for num, entry in toc_lookup.items() if entry.level == 1 and num and num.isdigit()]
-    if not chapter_numbers:
+    chapter_entries = []
+    for num in toc_lookup:
+        sn = parse_section_number(num)
+        if sn and sn.is_chapter:
+            chapter_entries.append((sn.chapter_num, num))
+    if not chapter_entries:
         return None
-    return min(chapter_numbers, key=lambda x: int(x))
+    return min(chapter_entries, key=lambda x: x[0])[1]
 
 
 def _build_hierarchical_structure(
@@ -58,33 +91,35 @@ def _build_hierarchical_structure(
         page_assignments: Dict mapping section number to pages
         toc_lookup: Dict mapping section number to TOCEntry
     """
-    # Group sections by chapter
-    chapters: dict[str, dict[str, list[ET.Element]]] = {}
+    # Group sections by chapter number (int)
+    chapters: dict[int, dict[str, list[ET.Element]]] = {}
 
     for section_num, pages in page_assignments.items():
         section_parts = parse_section_number(section_num)
         if not section_parts:
             continue
 
-        chapter_num = str(section_parts.chapter_num)
+        ch_num = section_parts.chapter_num
 
-        if chapter_num not in chapters:
-            chapters[chapter_num] = {}
+        if ch_num not in chapters:
+            chapters[ch_num] = {}
 
-        chapters[chapter_num][section_num] = pages
+        chapters[ch_num][section_num] = pages
 
     # Build chapter elements
-    for chapter_num in sorted(chapters.keys(), key=lambda x: int(x)):
-        chapter_entry = toc_lookup.get(chapter_num)
+    for ch_num in sorted(chapters.keys()):
+        # Find chapter TOC entry (handles both "1" and "1.0.0" keys)
+        chapter_key = _find_toc_key(str(ch_num), toc_lookup)
+        chapter_entry = toc_lookup.get(chapter_key) if chapter_key else None
         if not chapter_entry:
             continue
 
         chapter_elem = ET.Element("chapter")
-        chapter_elem.set("number", chapter_num)
+        chapter_elem.set("number", chapter_key)
         chapter_elem.set("title", chapter_entry.title)
 
         # Get sections in this chapter
-        chapter_sections = chapters[chapter_num]
+        chapter_sections = chapters[ch_num]
 
         # Add pages to chapter
         _add_sections_to_chapter(chapter_elem, chapter_sections, toc_lookup)
@@ -92,15 +127,14 @@ def _build_hierarchical_structure(
         book_elem.append(chapter_elem)
 
     # Handle chapters from TOC that don't have pages yet
-    for entry in toc_lookup.values():
-        if entry.level == 1:  # chapter level
-            chapter_num = entry.number
-            if chapter_num not in chapters:
-                # Create empty chapter
-                chapter_elem = ET.Element("chapter")
-                chapter_elem.set("number", chapter_num)
-                chapter_elem.set("title", entry.title)
-                book_elem.append(chapter_elem)
+    existing_ch_nums = set(chapters.keys())
+    for num, entry in toc_lookup.items():
+        sn = parse_section_number(num)
+        if sn and sn.is_chapter and sn.chapter_num not in existing_ch_nums:
+            chapter_elem = ET.Element("chapter")
+            chapter_elem.set("number", num)
+            chapter_elem.set("title", entry.title)
+            book_elem.append(chapter_elem)
 
 
 def _add_sections_to_chapter(
@@ -131,20 +165,24 @@ def _add_sections_to_chapter(
                     page.set("type", "chapter-title")
                 chapter_elem.append(page)
         elif section_parts.is_section:
-            # Section level
+            # Section level - use the actual key from page_assignments
             if section_num not in section_map:
                 section_map[section_num] = {}
             section_map[section_num]["_pages"] = pages
         elif section_parts.is_subsection:
-            # Subsection - find parent section
-            parent_section = ".".join(section_num.split(".")[:2])
-            if parent_section not in section_map:
-                section_map[parent_section] = {}
-            section_map[parent_section][section_num] = pages
+            # Subsection - find parent section key
+            # For "1.1.1" -> try "1.1", then "1.1.0" etc.
+            effective = section_parts.effective_parts
+            parent_effective = ".".join(str(p) for p in effective[:2])
+            parent_key = _find_toc_key(parent_effective, toc_lookup) or parent_effective
+            if parent_key not in section_map:
+                section_map[parent_key] = {}
+            section_map[parent_key][section_num] = pages
 
     # Build section elements
     for section_num in sorted(section_map.keys(), key=_section_sort_key):
-        section_entry = toc_lookup.get(section_num)
+        section_key = _find_toc_key(section_num, toc_lookup)
+        section_entry = toc_lookup.get(section_key) if section_key else None
         if not section_entry:
             continue
 
@@ -162,7 +200,8 @@ def _add_sections_to_chapter(
             if subsection_num == "_pages":
                 continue
 
-            subsection_entry = toc_lookup.get(subsection_num)
+            sub_key = _find_toc_key(subsection_num, toc_lookup)
+            subsection_entry = toc_lookup.get(sub_key) if sub_key else None
             if not subsection_entry:
                 continue
 
@@ -280,29 +319,30 @@ def _build_chapters(
     """
     from src.book_converter.models import Chapter
 
-    # Group by chapter number
-    chapters_data: dict[str, dict[str, list[Page]]] = {}
+    # Group by chapter number (int)
+    chapters_data: dict[int, dict[str, list[Page]]] = {}
 
     for section_num, pages in page_assignments.items():
         section_parts = parse_section_number(section_num)
         if not section_parts:
             continue
 
-        chapter_num = str(section_parts.chapter_num)
-        if chapter_num not in chapters_data:
-            chapters_data[chapter_num] = {}
-        chapters_data[chapter_num][section_num] = pages
+        ch_num = section_parts.chapter_num
+        if ch_num not in chapters_data:
+            chapters_data[ch_num] = {}
+        chapters_data[ch_num][section_num] = pages
 
     # Build Chapter objects
     chapters = []
-    for chapter_num in sorted(chapters_data.keys(), key=lambda x: int(x) if x.isdigit() else 0):
-        chapter_entry = toc_lookup.get(chapter_num)
+    for ch_num in sorted(chapters_data.keys()):
+        chapter_key = _find_toc_key(str(ch_num), toc_lookup)
+        chapter_entry = toc_lookup.get(chapter_key) if chapter_key else None
         if not chapter_entry:
             continue
 
-        sections = _build_sections(chapters_data[chapter_num], toc_lookup, chapter_entry)
+        sections = _build_sections(chapters_data[ch_num], toc_lookup, chapter_entry)
         chapter = Chapter(
-            number=chapter_num,
+            number=chapter_key,
             title=chapter_entry.text,
             sections=sections,
         )

--- a/src/book_converter/page_grouper/models.py
+++ b/src/book_converter/page_grouper/models.py
@@ -33,19 +33,30 @@ class SectionNumber:
         return self.parts[0]
 
     @property
+    def effective_parts(self) -> tuple[int, ...]:
+        """Strip trailing zeros to get effective hierarchy parts.
+
+        Handles numbering like 1.0.0 (chapter), 1.1.0 (section), 1.1.1 (subsection).
+        """
+        parts_list = list(self.parts)
+        while len(parts_list) > 1 and parts_list[-1] == 0:
+            parts_list.pop()
+        return tuple(parts_list)
+
+    @property
     def is_chapter(self) -> bool:
         """Return True if this is a chapter number."""
-        return len(self.parts) == 1
+        return len(self.effective_parts) == 1
 
     @property
     def is_section(self) -> bool:
         """Return True if this is a section number."""
-        return len(self.parts) == 2
+        return len(self.effective_parts) == 2
 
     @property
     def is_subsection(self) -> bool:
         """Return True if this is a subsection number."""
-        return len(self.parts) >= 3
+        return len(self.effective_parts) >= 3
 
 
 @dataclass(frozen=True)

--- a/src/book_converter/page_grouper/toc.py
+++ b/src/book_converter/page_grouper/toc.py
@@ -7,6 +7,24 @@ from xml.etree import ElementTree as ET
 from src.book_converter.errors import PageValidationError
 
 from .models import TOCEntry
+from .section import parse_section_number
+
+
+def _infer_level_from_number(number: str) -> int | None:
+    """Infer hierarchy level from section number pattern.
+
+    Uses trailing-zero convention: 1.0.0=chapter, 1.1.0=section, 1.1.1=subsection.
+
+    Args:
+        number: Section number string
+
+    Returns:
+        Inferred level (1-3) or None if cannot infer
+    """
+    sn = parse_section_number(number)
+    if not sn:
+        return None
+    return min(len(sn.effective_parts), 3)
 
 
 def _normalize_level(level: str) -> int:
@@ -45,9 +63,13 @@ def parse_toc(toc_element: ET.Element) -> list[TOCEntry]:
     entries = []
     for entry in toc_element.findall("entry"):
         level_raw = entry.get("level", "")
-        level = _normalize_level(level_raw)
         number = entry.get("number", "")
         title = entry.get("title", "")
+
+        # Prefer level inferred from number pattern (handles trailing-zero convention)
+        inferred = _infer_level_from_number(number)
+        level = inferred if inferred is not None else _normalize_level(level_raw)
+
         entries.append(TOCEntry(level=level, number=number, title=title))
     return entries
 

--- a/tests/book_converter/test_page_grouper.py
+++ b/tests/book_converter/test_page_grouper.py
@@ -18,6 +18,8 @@ from src.book_converter.page_grouper import (
     parse_section_number,
     parse_toc,
 )
+from src.book_converter.page_grouper.hierarchy import _find_toc_key
+from src.book_converter.page_grouper.toc import _infer_level_from_number
 
 # =============================================================================
 # Helper Functions for Phase 7 (page comments instead of page tags)
@@ -373,6 +375,81 @@ class TestParseSectionNumber:
         assert result.is_chapter is False
         assert result.is_section is False
         assert result.is_subsection is True
+
+    def test_trailing_zero_chapter(self) -> None:
+        """Test 1.0.0 format is recognized as chapter."""
+        result = parse_section_number("1.0.0")
+        assert result is not None
+        assert result.effective_parts == (1,)
+        assert result.is_chapter is True
+        assert result.is_section is False
+        assert result.is_subsection is False
+        assert result.chapter_num == 1
+
+    def test_trailing_zero_section(self) -> None:
+        """Test 1.1.0 format is recognized as section."""
+        result = parse_section_number("1.1.0")
+        assert result is not None
+        assert result.effective_parts == (1, 1)
+        assert result.is_chapter is False
+        assert result.is_section is True
+        assert result.is_subsection is False
+
+    def test_trailing_zero_subsection(self) -> None:
+        """Test 1.1.1 is still subsection (no trailing zeros)."""
+        result = parse_section_number("1.1.1")
+        assert result is not None
+        assert result.effective_parts == (1, 1, 1)
+        assert result.is_subsection is True
+
+    def test_single_trailing_zero(self) -> None:
+        """Test 2.0 format is recognized as chapter."""
+        result = parse_section_number("2.0")
+        assert result is not None
+        assert result.effective_parts == (2,)
+        assert result.is_chapter is True
+
+
+class TestFindTocKey:
+    """Tests for _find_toc_key helper."""
+
+    def test_direct_match(self) -> None:
+        lookup = {"1": "ch1", "1.1": "sec1.1"}
+        assert _find_toc_key("1", lookup) == "1"
+        assert _find_toc_key("1.1", lookup) == "1.1"
+
+    def test_zero_padded_chapter(self) -> None:
+        lookup = {"1.0.0": "ch1", "2.0.0": "ch2"}
+        assert _find_toc_key("1", lookup) == "1.0.0"
+        assert _find_toc_key("2", lookup) == "2.0.0"
+
+    def test_zero_padded_section(self) -> None:
+        lookup = {"1.1.0": "sec1.1"}
+        assert _find_toc_key("1.1", lookup) == "1.1.0"
+
+    def test_not_found(self) -> None:
+        lookup = {"1.0.0": "ch1"}
+        assert _find_toc_key("99", lookup) is None
+
+
+class TestInferLevelFromNumber:
+    """Tests for _infer_level_from_number."""
+
+    def test_chapter_formats(self) -> None:
+        assert _infer_level_from_number("1") == 1
+        assert _infer_level_from_number("1.0.0") == 1
+        assert _infer_level_from_number("2.0") == 1
+
+    def test_section_formats(self) -> None:
+        assert _infer_level_from_number("1.1") == 2
+        assert _infer_level_from_number("1.1.0") == 2
+
+    def test_subsection_formats(self) -> None:
+        assert _infer_level_from_number("1.1.1") == 3
+        assert _infer_level_from_number("1.2.3.4") == 3
+
+    def test_invalid(self) -> None:
+        assert _infer_level_from_number("abc") is None
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- page_grouperが `1.0.0` (chapter), `1.1.0` (section), `1.1.1` (subsection) の末尾ゼロ番号体系でページグルーピングに失敗していた問題を修正
- `SectionNumber.effective_parts` で末尾ゼロを除去し正しい階層判定
- `_find_toc_key()` で `"1"` → `"1.0.0"` の自動キー解決
- `parse_toc()` で番号パターンからレベルを推論（XML属性の誤ったlevel値に依存しない）

Closes #40

## Test plan

- [x] 既存テスト全通過 (1541 passed)
- [x] 末尾ゼロ形式の SectionNumber テスト追加 (4件)
- [x] `_find_toc_key` テスト追加 (4件)
- [x] `_infer_level_from_number` テスト追加 (4件)
- [x] 実データ (`output/65261d6efc0e35ab/book.md`) で354ページ全て正常にグルーピング確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)