### PR TITLE
feat: TOC正規化スクリプトの作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LIMIT_OPT := $(if $(LIMIT),--limit $(LIMIT),)
 INPUT_MD ?=
 OUTPUT_XML ?=
 
-.PHONY: help setup run extract-frames deduplicate split-spreads detect-layout run-ocr consolidate preview-extract preview-trim preview-trim-grid test test-book-converter test-cov converter convert-sample heading-report normalize-headings ruff pylint lint clean clean-all
+.PHONY: help setup run extract-frames deduplicate split-spreads detect-layout run-ocr consolidate preview-extract preview-trim preview-trim-grid test test-book-converter test-cov converter convert-sample heading-report normalize-toc normalize-headings ruff pylint lint clean clean-all
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -170,11 +170,13 @@ heading-report: setup ## Generate heading pattern report (requires HASHDIR)
 	@test -n "$(HASHDIR)" || { echo "Error: HASHDIR required. Usage: make heading-report HASHDIR=output/<hash>"; exit 1; }
 	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.cli.normalize_headings report "$(HASHDIR)/book.md"
 
+normalize-toc: setup ## Normalize OCR errors in TOC entries (requires HASHDIR, optional APPLY=1)
+	@test -n "$(HASHDIR)" || { echo "Error: HASHDIR required. Usage: make normalize-toc HASHDIR=output/<hash> [APPLY=1]"; exit 1; }
+	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.cli.normalize_toc "$(HASHDIR)/book.md" $(if $(APPLY),--apply)
+
 normalize-headings: setup ## Normalize headings to match TOC (requires HASHDIR, optional APPLY=1)
 	@test -n "$(HASHDIR)" || { echo "Error: HASHDIR required. Usage: make normalize-headings HASHDIR=output/<hash> [APPLY=1]"; exit 1; }
 	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.cli.normalize_headings normalize "$(HASHDIR)/book.md" $(if $(APPLY),--apply)
-
-# validate-toc は normalize-headings の機能のサブセットであったため削除
 
 # === Testing ===
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -18,6 +18,10 @@
                                                            ↓
                                                         book.md (構造化)
                                                            ↓
+                                                   TOC正規化 (OCRエラー修正)
+                                                           ↓
+                                                   見出し正規化 (TOC→本文)
+                                                           ↓
                                                         XML変換
                                                            ↓
                                                         book.xml (TTS対応)
@@ -597,6 +601,74 @@ sed -i 's/0(log n)/O(log n)/g' book.md
 
 # 不要な空白削除
 sed -i 's/第 \([0-9]\)章/第\1章/g' book.md
+```
+
+---
+
+### Step 5.5: TOC正規化（book.md のTOCエントリのOCRエラー修正）
+
+**目的**: TOCセクション内のOCRエラーを検出・修正し、後続の見出し正規化の精度を向上
+
+**前提条件**: book.md に `<!-- toc -->` / `<!-- /toc -->` マーカーが追加済みであること
+
+**コマンド**:
+```bash
+# プレビュー（dry-run、デフォルト）
+make normalize-toc HASHDIR=output/<hash>
+
+# 適用
+make normalize-toc HASHDIR=output/<hash> APPLY=1
+```
+
+**検出・修正するOCRエラーパターン**:
+
+| パターン | 変換前 | 変換後 |
+|---------|--------|--------|
+| 全角スラッシュ | `CI／CD` | `CI/CD` |
+| 全角コロン | `現在：SREの統合` | `現在:SREの統合` |
+| 全角括弧 | `（テスト）` | `(テスト)` |
+| 全角数字 | `１.２.３` | `1.2.3` |
+| 全角英字 | `ＡＢＣ` | `ABC` |
+| 不要スペース | `SLI / SLO` | `SLI/SLO` |
+| 全角スペース | `テスト　項目` | `テスト 項目` |
+| 中黒バリアント | `•（BULLET）` | `·（MIDDLE DOT）` |
+
+**出力例（dry-run）**:
+```
+Found 1 fix(es):
+
+  L425: fullwidth '：' -> ':' (FULLWIDTH COLON)
+    - 9.1.3 現在：SREの統合と役割の定義
+    + 9.1.3 現在:SREの統合と役割の定義
+
+Dry-run: 1 fix(es) found. Use --apply to apply.
+```
+
+**注意: TOC正規化と見出し正規化の依存関係**:
+
+> TOC正規化と見出し正規化は同じ book.md を対象に、互いに関連するテキストを修正します。
+> 片方を適用した後にもう片方を再実行すると、結果が変わる可能性があります。
+>
+> - **TOC正規化** → TOCエントリのテキストが変わる → **見出し正規化のマッチング結果が変わる**
+> - **見出し正規化** → 本文見出しのテキストが変わる → **TOC正規化の必要性が変わることがある**
+>
+> 必ず以下の順序で実行し、片方を修正したらもう片方を再確認してください。
+
+**推奨フロー**:
+```bash
+# 1. TOC正規化（プレビュー → 確認 → 適用）
+make normalize-toc HASHDIR=output/<hash>
+make normalize-toc HASHDIR=output/<hash> APPLY=1
+
+# 2. 見出し正規化（TOC正規化の後に実行）
+make normalize-headings HASHDIR=output/<hash>
+make normalize-headings HASHDIR=output/<hash> APPLY=1
+
+# 3. 再確認: TOC正規化を再実行して残りがないか確認
+make normalize-toc HASHDIR=output/<hash>
+
+# 4. XML変換
+make converter INPUT_MD=output/<hash>/book.md OUTPUT_XML=output/<hash>/book.xml
 ```
 
 ---

--- a/src/cli/normalize_headings.py
+++ b/src/cli/normalize_headings.py
@@ -4,6 +4,11 @@ Provides subcommands:
 - report: heading pattern analysis report
 - normalize: normalize headings (dry-run or apply)
 - validate: TOC-body heading validation report
+
+NOTE: このスクリプトは normalize_toc.py と相互に影響します。
+  - TOC正規化でエントリのテキストが変わると、見出し正規化のマッチング結果が変わる
+  - 見出し正規化で本文見出しが変わると、TOC正規化の必要性が変わることがある
+  推奨実行順序: normalize_toc → normalize_headings → normalize_toc (再確認)
 """
 
 from __future__ import annotations

--- a/src/cli/normalize_toc.py
+++ b/src/cli/normalize_toc.py
@@ -1,0 +1,297 @@
+"""CLI entry point for TOC normalization.
+
+Detects and fixes OCR errors in TOC entries within book.md:
+- Fullwidth -> halfwidth conversion (／ -> /, ： -> :, fullwidth digits)
+- Unnecessary space removal around slashes/symbols
+- Middle dot normalization
+
+NOTE: このスクリプトは normalize_headings.py と相互に影響します。
+  - TOC正規化でエントリのテキストが変わると、見出し正規化のマッチング結果が変わる
+  - 見出し正規化で本文見出しが変わると、TOC正規化の必要性が変わることがある
+  推奨実行順序: normalize_toc → normalize_headings → normalize_toc (再確認)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TocFix:
+    """A single fix to apply to a TOC line."""
+
+    line_number: int
+    original: str
+    fixed: str
+    reason: str
+
+
+# Fullwidth to halfwidth mapping
+_FULLWIDTH_MAP: dict[str, str] = {
+    "\uff0f": "/",  # ／ -> /
+    "\uff1a": ":",  # ： -> :
+    "\uff08": "(",  # （ -> (
+    "\uff09": ")",  # ） -> )
+    "\u3000": " ",  # ideographic space -> space
+}
+
+
+def _normalize_fullwidth_digits(text: str) -> str:
+    """Convert fullwidth digits to halfwidth."""
+    result = []
+    for ch in text:
+        if "\uff10" <= ch <= "\uff19":
+            result.append(chr(ord(ch) - 0xFEE0))
+        else:
+            result.append(ch)
+    return "".join(result)
+
+
+def _normalize_fullwidth_alpha(text: str) -> str:
+    """Convert fullwidth ASCII letters to halfwidth."""
+    result = []
+    for ch in text:
+        cp = ord(ch)
+        if 0xFF21 <= cp <= 0xFF3A:  # Ａ-Ｚ
+            result.append(chr(cp - 0xFEE0))
+        elif 0xFF41 <= cp <= 0xFF5A:  # ａ-ｚ
+            result.append(chr(cp - 0xFEE0))
+        else:
+            result.append(ch)
+    return "".join(result)
+
+
+def _apply_fullwidth_map(text: str) -> str:
+    """Apply fullwidth symbol to halfwidth mapping."""
+    for fw, hw in _FULLWIDTH_MAP.items():
+        text = text.replace(fw, hw)
+    return text
+
+
+def _remove_extra_spaces_around_symbols(text: str) -> str:
+    """Remove unnecessary spaces around / and other symbols.
+
+    Examples:
+        'CI／ CD' -> 'CI/CD' (after fullwidth conversion: 'CI/ CD' -> 'CI/CD')
+        'SLI / SLO' -> 'SLI/SLO'
+    """
+    # Remove spaces around /
+    text = re.sub(r"\s*/\s*", "/", text)
+    return text
+
+
+def _normalize_middle_dots(text: str) -> str:
+    """Normalize middle dot variants to standard middle dot (·).
+
+    Normalizes:
+    - U+00B7 MIDDLE DOT (·) - keep as-is
+    - U+2022 BULLET (•) -> ·
+    - U+30FB KATAKANA MIDDLE DOT (・) - keep as-is (standard Japanese)
+    """
+    text = text.replace("\u2022", "\u00b7")  # • -> ·
+    return text
+
+
+def normalize_toc_line(line: str) -> str:
+    """Apply all normalization rules to a TOC line.
+
+    Args:
+        line: A single TOC line.
+
+    Returns:
+        Normalized line.
+    """
+    result = line
+    result = _apply_fullwidth_map(result)
+    result = _normalize_fullwidth_digits(result)
+    result = _normalize_fullwidth_alpha(result)
+    result = _remove_extra_spaces_around_symbols(result)
+    result = _normalize_middle_dots(result)
+    return result
+
+
+def find_toc_fixes(lines: list[str]) -> list[TocFix]:
+    """Scan lines for TOC sections and find fixable OCR errors.
+
+    Args:
+        lines: All lines from book.md (with newlines stripped).
+
+    Returns:
+        List of TocFix objects describing each fix.
+    """
+    fixes: list[TocFix] = []
+    in_toc = False
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+
+        if re.match(r"<!--\s*toc\s*-->", stripped, re.IGNORECASE):
+            in_toc = True
+            continue
+        if re.match(r"<!--\s*/toc\s*-->", stripped, re.IGNORECASE):
+            in_toc = False
+            continue
+
+        if not in_toc:
+            continue
+
+        if not stripped:
+            continue
+
+        normalized = normalize_toc_line(line)
+        if normalized != line:
+            reasons = _describe_changes(line, normalized)
+            fixes.append(
+                TocFix(
+                    line_number=i + 1,
+                    original=line,
+                    fixed=normalized,
+                    reason=", ".join(reasons),
+                )
+            )
+
+    return fixes
+
+
+def _describe_changes(original: str, fixed: str) -> list[str]:
+    """Describe what changed between original and fixed."""
+    reasons: list[str] = []
+
+    for fw, hw in _FULLWIDTH_MAP.items():
+        if fw in original:
+            name = unicodedata.name(fw, fw)
+            reasons.append(f"fullwidth '{fw}' -> '{hw}' ({name})")
+
+    for ch in original:
+        if "\uff10" <= ch <= "\uff19":
+            reasons.append("fullwidth digits -> halfwidth")
+            break
+
+    for ch in original:
+        cp = ord(ch)
+        if 0xFF21 <= cp <= 0xFF3A or 0xFF41 <= cp <= 0xFF5A:
+            reasons.append("fullwidth alpha -> halfwidth")
+            break
+
+    if re.search(r"\s+/\s+", original) or re.search(r"\s+/", original) or re.search(r"/\s+", original):
+        reasons.append("extra spaces around /")
+
+    if "\u2022" in original:
+        reasons.append("bullet • -> middle dot ·")
+
+    if not reasons:
+        reasons.append("normalization")
+
+    return reasons
+
+
+def _display_width(text: str) -> int:
+    """Calculate display width of text (handles CJK characters)."""
+    width = 0
+    for char in text:
+        ea = unicodedata.east_asian_width(char)
+        if ea in ("F", "W", "A"):
+            width += 2
+        else:
+            width += 1
+    return width
+
+
+def print_preview(fixes: list[TocFix]) -> None:
+    """Print a preview of fixes to be applied."""
+    if not fixes:
+        print("No OCR errors found in TOC entries.")
+        return
+
+    print(f"Found {len(fixes)} fix(es):\n")
+    for fix in fixes:
+        print(f"  L{fix.line_number}: {fix.reason}")
+        print(f"    - {fix.original.strip()}")
+        print(f"    + {fix.fixed.strip()}")
+        print()
+
+
+def apply_fixes(lines: list[str], fixes: list[TocFix]) -> list[str]:
+    """Apply fixes to lines.
+
+    Args:
+        lines: Original lines.
+        fixes: Fixes to apply.
+
+    Returns:
+        New list of lines with fixes applied.
+    """
+    result = list(lines)
+    for fix in fixes:
+        idx = fix.line_number - 1
+        if result[idx] == fix.original:
+            result[idx] = fix.fixed
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point.
+
+    Args:
+        argv: Command-line arguments.
+
+    Returns:
+        Exit code (0 = success, 1 = error).
+    """
+    parser = argparse.ArgumentParser(
+        description="Normalize OCR errors in TOC entries of book.md",
+    )
+    parser.add_argument(
+        "book_md",
+        type=Path,
+        help="Path to book.md",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Apply fixes (default: dry-run preview only)",
+    )
+
+    args = parser.parse_args(argv)
+    book_path: Path = args.book_md
+
+    if not book_path.exists():
+        print(f"Error: {book_path} not found", file=sys.stderr)
+        return 1
+
+    content = book_path.read_text(encoding="utf-8")
+    lines = content.splitlines(keepends=True)
+    lines_stripped = [line.rstrip("\n") for line in lines]
+
+    fixes = find_toc_fixes(lines_stripped)
+
+    if not fixes:
+        print("No OCR errors found in TOC entries.")
+        return 0
+
+    print_preview(fixes)
+
+    if not args.apply:
+        print(f"Dry-run: {len(fixes)} fix(es) found. Use --apply to apply.")
+        return 0
+
+    # Rebuild with original line endings preserved
+    fixed_stripped = apply_fixes(lines_stripped, fixes)
+    fixed_lines = []
+    for orig, fixed in zip(lines, fixed_stripped):
+        ending = orig[len(orig.rstrip("\n")) :]
+        fixed_lines.append(fixed + ending)
+
+    book_path.write_text("".join(fixed_lines), encoding="utf-8")
+    print(f"Applied {len(fixes)} fix(es) to {book_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cli/test_normalize_toc.py
+++ b/tests/cli/test_normalize_toc.py
@@ -1,0 +1,124 @@
+"""Tests for TOC normalization CLI."""
+
+from __future__ import annotations
+
+from src.cli.normalize_toc import (
+    TocFix,
+    apply_fixes,
+    find_toc_fixes,
+    normalize_toc_line,
+)
+
+
+class TestNormalizeTocLine:
+    """Tests for normalize_toc_line."""
+
+    def test_fullwidth_slash(self) -> None:
+        assert normalize_toc_line("CI／CD") == "CI/CD"
+
+    def test_fullwidth_colon(self) -> None:
+        assert normalize_toc_line("現在：SREの統合") == "現在:SREの統合"
+
+    def test_fullwidth_digits(self) -> None:
+        assert normalize_toc_line("１.２.３ タイトル") == "1.2.3 タイトル"
+
+    def test_fullwidth_alpha(self) -> None:
+        assert normalize_toc_line("ＡＢＣ") == "ABC"
+
+    def test_extra_spaces_around_slash(self) -> None:
+        assert normalize_toc_line("SLI / SLO") == "SLI/SLO"
+
+    def test_fullwidth_slash_with_space(self) -> None:
+        assert normalize_toc_line("CI／ CD") == "CI/CD"
+
+    def test_bullet_to_middle_dot(self) -> None:
+        assert normalize_toc_line("• 項目") == "· 項目"
+
+    def test_no_change(self) -> None:
+        line = "1.1.0 SREの概要"
+        assert normalize_toc_line(line) == line
+
+    def test_ideographic_space(self) -> None:
+        assert normalize_toc_line("テスト\u3000項目") == "テスト 項目"
+
+    def test_fullwidth_parens(self) -> None:
+        assert normalize_toc_line("（テスト）") == "(テスト)"
+
+
+class TestFindTocFixes:
+    """Tests for find_toc_fixes."""
+
+    def test_finds_fixes_in_toc_section(self) -> None:
+        lines = [
+            "--- page_0008 ---",
+            "",
+            "<!-- toc -->",
+            "1.0.0 CI／CD",
+            "1.1.0 正常なエントリ",
+            "<!-- /toc -->",
+        ]
+        fixes = find_toc_fixes(lines)
+        assert len(fixes) == 1
+        assert fixes[0].line_number == 4
+        assert fixes[0].original == "1.0.0 CI／CD"
+        assert fixes[0].fixed == "1.0.0 CI/CD"
+
+    def test_ignores_non_toc_lines(self) -> None:
+        lines = [
+            "CI／CD outside TOC",
+            "<!-- toc -->",
+            "1.0.0 正常",
+            "<!-- /toc -->",
+            "CI／CD also outside",
+        ]
+        fixes = find_toc_fixes(lines)
+        assert len(fixes) == 0
+
+    def test_multiple_toc_sections(self) -> None:
+        lines = [
+            "<!-- toc -->",
+            "1.0.0 テスト１",
+            "<!-- /toc -->",
+            "",
+            "<!-- toc -->",
+            "2.0.0 テスト２",
+            "<!-- /toc -->",
+        ]
+        fixes = find_toc_fixes(lines)
+        assert len(fixes) == 2
+
+    def test_empty_toc(self) -> None:
+        lines = [
+            "<!-- toc -->",
+            "",
+            "<!-- /toc -->",
+        ]
+        fixes = find_toc_fixes(lines)
+        assert len(fixes) == 0
+
+    def test_no_toc_markers(self) -> None:
+        lines = ["CI／CD", "SLI / SLO"]
+        fixes = find_toc_fixes(lines)
+        assert len(fixes) == 0
+
+
+class TestApplyFixes:
+    """Tests for apply_fixes."""
+
+    def test_apply_single_fix(self) -> None:
+        lines = ["line 1", "CI／CD", "line 3"]
+        fixes = [TocFix(line_number=2, original="CI／CD", fixed="CI/CD", reason="test")]
+        result = apply_fixes(lines, fixes)
+        assert result == ["line 1", "CI/CD", "line 3"]
+
+    def test_apply_no_fixes(self) -> None:
+        lines = ["line 1", "line 2"]
+        result = apply_fixes(lines, [])
+        assert result == lines
+
+    def test_does_not_mutate_original(self) -> None:
+        lines = ["CI／CD"]
+        fixes = [TocFix(line_number=1, original="CI／CD", fixed="CI/CD", reason="test")]
+        result = apply_fixes(lines, fixes)
+        assert lines == ["CI／CD"]
+        assert result == ["CI/CD"]


### PR DESCRIPTION
## Summary
- TOCセクション内のOCRエラー（全角→半角、不要スペース、中黒統一）を検出・修正するCLIスクリプトを追加
- `make normalize-toc HASHDIR=... [APPLY=1]` で実行
- `normalize_toc` / `normalize_headings` 双方に相互依存の注意書きを追加
- `docs/WORKFLOW.md` に Step 5.5 として記載

Closes #39

## Test plan
- [x] `make test` 全件パス (1559 passed)
- [x] `make normalize-toc HASHDIR=output/65261d6efc0e35ab` で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)