### PR TITLE
feat: 箇条書き記号のクリーンアップ処理

### DIFF
--- a/src/book_converter/bullet_cleanup.py
+++ b/src/book_converter/bullet_cleanup.py
@@ -1,0 +1,133 @@
+"""Bullet marker cleanup for book converter.
+
+Provides two post-processing functions:
+1. strip_heading_markers: Remove leading bullet markers from Heading text
+2. merge_bullet_paragraphs_to_lists: Convert consecutive bullet-marked Paragraphs to List
+"""
+
+from __future__ import annotations
+
+from src.book_converter.models import (
+    Heading,
+    List,
+    Paragraph,
+)
+from src.book_converter.parser.utils import BULLET_MARKERS
+
+# Markers used for heading/paragraph cleanup
+# Exclude "-" and "*" as they are standard markdown markers, not OCR artifacts
+_CLEANUP_MARKERS = tuple(m for m in BULLET_MARKERS if m not in ("-", "*"))
+
+
+def strip_heading_markers(heading: Heading) -> Heading:
+    """Remove leading bullet marker from heading text.
+
+    Args:
+        heading: The Heading to clean.
+
+    Returns:
+        New Heading with marker stripped, or the original if no marker found.
+    """
+    text = heading.text
+    for marker in _CLEANUP_MARKERS:
+        if text.startswith(marker):
+            cleaned = text[len(marker) :].lstrip()
+            if cleaned:
+                return Heading(
+                    level=heading.level,
+                    text=cleaned,
+                    read_aloud=heading.read_aloud,
+                    line_number=heading.line_number,
+                    page=heading.page,
+                )
+    return heading
+
+
+def _get_bullet_marker(text: str) -> str | None:
+    """Extract the leading bullet marker from text, if any.
+
+    Returns:
+        The marker character, or None if no marker found.
+    """
+    for marker in _CLEANUP_MARKERS:
+        if text.startswith(marker):
+            rest = text[len(marker) :].lstrip()
+            if rest:
+                return marker
+    return None
+
+
+def _strip_marker(text: str, marker: str) -> str:
+    """Strip a known marker from the start of text."""
+    return text[len(marker) :].lstrip()
+
+
+def merge_bullet_paragraphs_to_lists(
+    elements: tuple,
+) -> tuple:
+    """Convert consecutive same-marker Paragraphs into List elements.
+
+    Rules:
+    - Only Paragraph elements with leading bullet markers are candidates
+    - 2+ consecutive Paragraphs with the SAME marker become a List
+    - Single bullet Paragraphs are left unchanged
+    - Non-Paragraph elements break a run
+
+    Args:
+        elements: Tuple of content elements (Heading, Paragraph, List, etc.)
+
+    Returns:
+        New tuple with bullet runs replaced by List elements.
+    """
+    if not elements:
+        return ()
+
+    result: list = []
+    i = 0
+    n = len(elements)
+
+    while i < n:
+        elem = elements[i]
+
+        # Only process Paragraph elements
+        if not isinstance(elem, Paragraph):
+            result.append(elem)
+            i += 1
+            continue
+
+        marker = _get_bullet_marker(elem.text)
+        if marker is None:
+            result.append(elem)
+            i += 1
+            continue
+
+        # Start of potential run — collect consecutive same-marker paragraphs
+        run_start = i
+        run_read_aloud = elem.read_aloud
+        i += 1
+        while i < n:
+            next_elem = elements[i]
+            if not isinstance(next_elem, Paragraph):
+                break
+            next_marker = _get_bullet_marker(next_elem.text)
+            if next_marker != marker:
+                break
+            i += 1
+
+        run_length = i - run_start
+
+        if run_length >= 2:
+            # Convert to List
+            items = tuple(_strip_marker(elements[j].text, marker) for j in range(run_start, i))
+            result.append(
+                List(
+                    items=items,
+                    list_type="unordered",
+                    read_aloud=run_read_aloud,
+                )
+            )
+        else:
+            # Single bullet paragraph — leave as-is
+            result.append(elements[run_start])
+
+    return tuple(result)

--- a/src/book_converter/transformer.py
+++ b/src/book_converter/transformer.py
@@ -7,6 +7,10 @@ from __future__ import annotations
 
 from xml.etree.ElementTree import Element, SubElement
 
+from src.book_converter.bullet_cleanup import (
+    merge_bullet_paragraphs_to_lists,
+    strip_heading_markers,
+)
 from src.book_converter.models import (
     Book,
     BookMetadata,
@@ -139,12 +143,13 @@ def transform_section(section: Section) -> Element:
         elem.set("number", section.number)
     elem.set("title", section.title)
 
-    for child in section.elements:
+    cleaned = merge_bullet_paragraphs_to_lists(section.elements)
+    for child in cleaned:
         if isinstance(child, Paragraph):
             child_elem = transform_paragraph(child)
             elem.append(child_elem)
         elif isinstance(child, Heading):
-            child_elem = transform_heading(child)
+            child_elem = transform_heading(strip_heading_markers(child))
             elem.append(child_elem)
         elif isinstance(child, List):
             child_elem = transform_list(child)
@@ -371,17 +376,19 @@ def transform_content(content: Content) -> Element | None:
     elem = Element("content")
     elem.set("readAloud", "true" if content.read_aloud else "false")
 
-    for element in content.elements:
+    cleaned = merge_bullet_paragraphs_to_lists(content.elements)
+    for element in cleaned:
         if isinstance(element, Paragraph):
             para_elem = Element("paragraph")
             para_elem.set("readAloud", "true" if element.read_aloud else "false")
             apply_emphasis(element.text, para_elem)
             elem.append(para_elem)
         elif isinstance(element, Heading):
+            cleaned_heading = strip_heading_markers(element)
             heading_elem = Element("heading")
-            heading_elem.set("level", str(element.level))
-            heading_elem.set("readAloud", "true" if element.read_aloud else "false")
-            apply_emphasis(element.text, heading_elem)
+            heading_elem.set("level", str(cleaned_heading.level))
+            heading_elem.set("readAloud", "true" if cleaned_heading.read_aloud else "false")
+            apply_emphasis(cleaned_heading.text, heading_elem)
             elem.append(heading_elem)
         elif isinstance(element, List):
             list_elem = Element("list")
@@ -449,14 +456,16 @@ def transform_structure_container(container: StructureContainer) -> Element:
             elem.set("number", container.number)
         elem.set("title", container.title)
 
-    for child in container.children:
+    cleaned_children = merge_bullet_paragraphs_to_lists(container.children)
+    for child in cleaned_children:
         if isinstance(child, StructureContainer):
             child_elem = transform_structure_container(child)
             elem.append(child_elem)
         elif isinstance(child, Heading):
+            cleaned_heading = strip_heading_markers(child)
             heading_elem = Element("heading")
-            heading_elem.set("readAloud", "true" if child.read_aloud else "false")
-            apply_emphasis(child.text, heading_elem)
+            heading_elem.set("readAloud", "true" if cleaned_heading.read_aloud else "false")
+            apply_emphasis(cleaned_heading.text, heading_elem)
             elem.append(heading_elem)
         elif isinstance(child, Paragraph):
             para_elem = Element("paragraph")

--- a/tests/book_converter/test_bullet_cleanup.py
+++ b/tests/book_converter/test_bullet_cleanup.py
@@ -1,0 +1,230 @@
+"""Tests for bullet marker cleanup in book converter."""
+
+from __future__ import annotations
+
+from src.book_converter.bullet_cleanup import (
+    merge_bullet_paragraphs_to_lists,
+    strip_heading_markers,
+)
+from src.book_converter.models import (
+    CodeBlock,
+    Heading,
+    List,
+    Paragraph,
+)
+
+
+class TestStripHeadingMarkers:
+    """heading 先頭の箇条書き記号を除去するテスト"""
+
+    def test_strip_triangle_marker(self) -> None:
+        h = Heading(level=2, text="▶対象とする読者")
+        result = strip_heading_markers(h)
+        assert result.text == "対象とする読者"
+        assert result.level == 2
+
+    def test_strip_square_marker(self) -> None:
+        h = Heading(level=2, text="■免責")
+        result = strip_heading_markers(h)
+        assert result.text == "免責"
+
+    def test_strip_circle_marker(self) -> None:
+        h = Heading(level=2, text="●ご質問方法")
+        result = strip_heading_markers(h)
+        assert result.text == "ご質問方法"
+
+    def test_strip_marker_with_space(self) -> None:
+        h = Heading(level=2, text="▶ 対象とする読者")
+        result = strip_heading_markers(h)
+        assert result.text == "対象とする読者"
+
+    def test_no_marker_unchanged(self) -> None:
+        h = Heading(level=2, text="対象とする読者")
+        result = strip_heading_markers(h)
+        assert result.text == "対象とする読者"
+
+    def test_preserves_read_aloud(self) -> None:
+        h = Heading(level=2, text="▶謝辞", read_aloud=False)
+        result = strip_heading_markers(h)
+        assert result.text == "謝辞"
+        assert result.read_aloud is False
+
+    def test_preserves_line_number_and_page(self) -> None:
+        h = Heading(level=3, text="▶ビジネスへの影響", line_number=42, page="15")
+        result = strip_heading_markers(h)
+        assert result.text == "ビジネスへの影響"
+        assert result.line_number == 42
+        assert result.page == "15"
+
+    def test_numbered_heading_with_marker(self) -> None:
+        h = Heading(level=2, text="▶3. 定期的なレビュー")
+        result = strip_heading_markers(h)
+        assert result.text == "3. 定期的なレビュー"
+
+    def test_dot_marker(self) -> None:
+        h = Heading(level=2, text="・概要")
+        result = strip_heading_markers(h)
+        assert result.text == "概要"
+
+    def test_diamond_marker(self) -> None:
+        h = Heading(level=2, text="◆重要なポイント")
+        result = strip_heading_markers(h)
+        assert result.text == "重要なポイント"
+
+    def test_arrow_not_stripped(self) -> None:
+        """→ はBULLET_MARKERSに含まれないので除去しない"""
+        h = Heading(level=2, text="→次のステップ")
+        result = strip_heading_markers(h)
+        assert result.text == "→次のステップ"
+
+
+class TestMergeBulletParagraphsToLists:
+    """連続する記号付き paragraph を list に変換するテスト"""
+
+    def test_two_consecutive_bullets_become_list(self) -> None:
+        elements = (
+            Paragraph(text="●コードの品質が大事な理由"),
+            Paragraph(text="●高品質なコードが達成すべき4つのゴール"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert len(result) == 1
+        assert isinstance(result[0], List)
+        assert result[0].items == (
+            "コードの品質が大事な理由",
+            "高品質なコードが達成すべき4つのゴール",
+        )
+
+    def test_three_consecutive_bullets(self) -> None:
+        elements = (
+            Paragraph(text="■ サーバーのURL"),
+            Paragraph(text="■ メッセージ文字列の送信"),
+            Paragraph(text="■文字列から送信可能なフォーマットへのシリアライズ"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert len(result) == 1
+        assert isinstance(result[0], List)
+        assert len(result[0].items) == 3
+        assert result[0].items[0] == "サーバーのURL"
+
+    def test_single_bullet_not_converted(self) -> None:
+        elements = (
+            Paragraph(text="●孤立した項目"),
+            Paragraph(text="通常のテキスト"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert len(result) == 2
+        assert isinstance(result[0], Paragraph)
+        assert isinstance(result[1], Paragraph)
+
+    def test_non_bullet_paragraphs_unchanged(self) -> None:
+        elements = (
+            Paragraph(text="通常のテキスト1"),
+            Paragraph(text="通常のテキスト2"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert len(result) == 2
+        assert all(isinstance(e, Paragraph) for e in result)
+
+    def test_mixed_elements_preserved(self) -> None:
+        elements = (
+            Paragraph(text="本章の内容"),
+            Paragraph(text="●コードの品質が大事な理由"),
+            Paragraph(text="●高品質なコードが達成すべき4つのゴール"),
+            Paragraph(text="●高品質のコードを書くことで時間と労力を節約する方法"),
+            Paragraph(text="これまでに、さまざまなソフトウェアを利用してきたでしょう。"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert len(result) == 3
+        assert isinstance(result[0], Paragraph)
+        assert result[0].text == "本章の内容"
+        assert isinstance(result[1], List)
+        assert len(result[1].items) == 3
+        assert isinstance(result[2], Paragraph)
+
+    def test_heading_breaks_bullet_run(self) -> None:
+        elements = (
+            Paragraph(text="●項目1"),
+            Heading(level=2, text="見出し"),
+            Paragraph(text="●項目2"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert len(result) == 3
+        assert isinstance(result[0], Paragraph)  # 孤立 → 変換なし
+        assert isinstance(result[1], Heading)
+        assert isinstance(result[2], Paragraph)  # 孤立 → 変換なし
+
+    def test_different_markers_not_merged(self) -> None:
+        """異なる記号は別のリストとして扱う"""
+        elements = (
+            Paragraph(text="●項目A"),
+            Paragraph(text="■項目B"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        # 異なる記号なので連続としない
+        assert len(result) == 2
+        assert isinstance(result[0], Paragraph)
+        assert isinstance(result[1], Paragraph)
+
+    def test_same_marker_required(self) -> None:
+        """同一記号のみ連続とみなす"""
+        elements = (
+            Paragraph(text="■項目1"),
+            Paragraph(text="■項目2"),
+            Paragraph(text="●項目3"),
+            Paragraph(text="●項目4"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert len(result) == 2
+        assert isinstance(result[0], List)
+        assert result[0].items == ("項目1", "項目2")
+        assert isinstance(result[1], List)
+        assert result[1].items == ("項目3", "項目4")
+
+    def test_preserves_read_aloud_true(self) -> None:
+        elements = (
+            Paragraph(text="●項目1", read_aloud=True),
+            Paragraph(text="●項目2", read_aloud=True),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert isinstance(result[0], List)
+        assert result[0].read_aloud is True
+
+    def test_preserves_read_aloud_false(self) -> None:
+        elements = (
+            Paragraph(text="●項目1", read_aloud=False),
+            Paragraph(text="●項目2", read_aloud=False),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert isinstance(result[0], List)
+        assert result[0].read_aloud is False
+
+    def test_empty_elements(self) -> None:
+        result = merge_bullet_paragraphs_to_lists(())
+        assert result == ()
+
+    def test_code_block_not_affected(self) -> None:
+        elements = (
+            CodeBlock(text="print('hello')"),
+            Paragraph(text="●項目1"),
+            Paragraph(text="●項目2"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert len(result) == 2
+        assert isinstance(result[0], CodeBlock)
+        assert isinstance(result[1], List)
+
+    def test_multiple_runs_in_sequence(self) -> None:
+        elements = (
+            Paragraph(text="●項目A1"),
+            Paragraph(text="●項目A2"),
+            Paragraph(text="通常テキスト"),
+            Paragraph(text="■項目B1"),
+            Paragraph(text="■項目B2"),
+        )
+        result = merge_bullet_paragraphs_to_lists(elements)
+        assert len(result) == 3
+        assert isinstance(result[0], List)
+        assert result[0].items == ("項目A1", "項目A2")
+        assert isinstance(result[1], Paragraph)
+        assert isinstance(result[2], List)
+        assert result[2].items == ("項目B1", "項目B2")


### PR DESCRIPTION
## Summary

Closes #45

- `<heading>` 内の先頭箇条書き記号（▶●■◆◇等）を除去
- 同一記号の `<paragraph>` が2個以上連続する場合に `<list><item>` に構造化
- 新設計 (Section) / Legacy (Content, StructureContainer) 両パスに適用

## Changes

| ファイル | 内容 |
|---------|------|
| `src/book_converter/bullet_cleanup.py` | `strip_heading_markers()`, `merge_bullet_paragraphs_to_lists()` |
| `src/book_converter/transformer.py` | 3箇所でクリーンアップ適用 |
| `tests/book_converter/test_bullet_cleanup.py` | テスト24件 |

## Examples

**Heading marker removal:**
```xml
<!-- Before --> <heading level="2">▶対象とする読者</heading>
<!-- After  --> <heading level="2">対象とする読者</heading>
```

**Paragraph → List conversion:**
```xml
<!-- Before -->
<paragraph>●コードの品質が大事な理由</paragraph>
<paragraph>●高品質なコードが達成すべき4つのゴール</paragraph>

<!-- After -->
<list>
  <item>コードの品質が大事な理由</item>
  <item>高品質なコードが達成すべき4つのゴール</item>
</list>
```

## Scope

- `-` `*` は通常の Markdown 記号のため除外
- 異なる記号の混在リスト（サブリスト）は対象外
- 孤立した単一記号行は変換しない（誤検出リスク回避）

## Test plan

- [x] `make lint` パス
- [x] `make test` 全 1625 テストパス（新規 24 件含む）
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)