### PR TITLE
feat: CODE リージョン誤検出の精度改善

### DIFF
--- a/src/book_converter/code_block_filter.py
+++ b/src/book_converter/code_block_filter.py
@@ -1,0 +1,119 @@
+"""Filter false-positive code blocks back to paragraphs.
+
+Code blocks detected from gray background regions may contain non-code content
+such as book references, short OCR artifacts, or Japanese prose. This module
+provides filtering to demote such false positives to paragraphs.
+"""
+
+from __future__ import annotations
+
+import re
+
+from src.book_converter.models import CodeBlock, Paragraph
+
+# Minimum character count for a code block to be kept as-is
+_MIN_CODE_LENGTH = 10
+
+# Symbol ratio threshold for code indicators in filter context.
+# Lower than code_detector's 0.08 because we only need a hint of code presence.
+_CODE_SYMBOL_RATIO_THRESHOLD = 0.05
+
+# Japanese character pattern (hiragana, katakana, CJK unified ideographs)
+_JAPANESE_PATTERN = re.compile(r"[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff]")
+
+# Code indicator patterns (symbols and keywords that suggest real code)
+# Exclude +, -, / which are common in ISBNs, URLs, book references
+_CODE_INDICATOR_SYMBOLS = frozenset("{}();=<>[]&|*%#@^~\\")
+
+_CODE_INDICATOR_KEYWORDS = [
+    "def ",
+    "func ",
+    "fn ",
+    "class ",
+    "import ",
+    "return ",
+    "if (",
+    "for (",
+    "while (",
+    "public ",
+    "private ",
+    "void ",
+    "int ",
+    "String ",
+    "var ",
+    "val ",
+    "let ",
+    "const ",
+    "=>",
+    ":=",
+    "->",
+    "::=",
+    "std::",
+    "#include",
+    "#!/",
+]
+
+
+def _has_code_indicators(text: str) -> bool:
+    """Check if text contains programming indicators.
+
+    Returns True if text has a meaningful symbol ratio or code keywords.
+    """
+    if not text:
+        return False
+
+    # Check symbol ratio
+    symbol_count = sum(1 for ch in text if ch in _CODE_INDICATOR_SYMBOLS)
+    ratio = symbol_count / len(text)
+    if ratio > _CODE_SYMBOL_RATIO_THRESHOLD:
+        return True
+
+    # Check keywords
+    lower = text.lower()
+    keyword_count = sum(1 for kw in _CODE_INDICATOR_KEYWORDS if kw.lower() in lower)
+    if keyword_count >= 1:
+        return True
+
+    return False
+
+
+def _japanese_ratio(text: str) -> float:
+    """Calculate the ratio of Japanese characters in text."""
+    if not text:
+        return 0.0
+    jp_count = len(_JAPANESE_PATTERN.findall(text))
+    return jp_count / len(text)
+
+
+def filter_code_block(code_block: CodeBlock) -> CodeBlock | Paragraph | None:
+    """Filter a code block, returning the appropriate element type.
+
+    Rules:
+    1. Empty code blocks -> None (removed)
+    2. Very short text (< _MIN_CODE_LENGTH) without code indicators -> Paragraph
+    3. High Japanese ratio (> 0.3) without code indicators -> Paragraph
+    4. Otherwise -> keep as CodeBlock
+
+    Args:
+        code_block: CodeBlock to evaluate.
+
+    Returns:
+        CodeBlock (kept), Paragraph (demoted), or None (removed).
+    """
+    text = code_block.text.strip()
+
+    # Rule 1: Empty code blocks are removed
+    if not text:
+        return None
+
+    # Rule 2: Very short text without code indicators
+    if len(text) < _MIN_CODE_LENGTH and not _has_code_indicators(text):
+        return Paragraph(text=text, read_aloud=True)
+
+    # Rule 3: High Japanese ratio without code indicators
+    jp_ratio = _japanese_ratio(text)
+    if jp_ratio > 0.3 and not _has_code_indicators(text):
+        return Paragraph(text=text, read_aloud=True)
+
+    # Keep as code block
+    return code_block

--- a/src/book_converter/parser/page.py
+++ b/src/book_converter/parser/page.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator
 
+from src.book_converter.code_block_filter import filter_code_block
 from src.book_converter.models import (
     CodeBlock,
     Content,
@@ -655,7 +656,9 @@ def _parse_single_page_content(
         if is_fence:
             code_block, next_idx = _collect_code_block(lines, idx)
             if code_block is not None:
-                state.content_elements.append(code_block)
+                filtered = filter_code_block(code_block)
+                if filtered is not None:
+                    state.content_elements.append(filtered)
             idx = next_idx
             continue
 

--- a/src/layout/code_detector.py
+++ b/src/layout/code_detector.py
@@ -21,6 +21,8 @@ _DEFAULT_CODE_DETECTION_CONFIG: dict = {
     "symbol_ratio_threshold": 0.08,
     "keyword_threshold": 2,
     "fragment_gap_threshold": 80,
+    "min_region_width": 100,
+    "min_region_height": 60,
 }
 
 
@@ -77,6 +79,8 @@ def load_code_detection_config(config_path: str | None = None) -> dict:
     result["symbol_ratio_threshold"] = float(result["symbol_ratio_threshold"])
     result["keyword_threshold"] = int(result["keyword_threshold"])
     result["fragment_gap_threshold"] = int(result["fragment_gap_threshold"])
+    result["min_region_width"] = int(result["min_region_width"])
+    result["min_region_height"] = int(result["min_region_height"])
 
     return result
 
@@ -283,6 +287,8 @@ def is_code_fragment(text: str | None) -> bool:
 def merge_code_fragments(
     regions: list[dict],
     gap_threshold: int = 80,
+    min_region_width: int = 100,
+    min_region_height: int = 60,
 ) -> list[dict]:
     """Merge adjacent CODE and code-fragment regions into single CODE regions.
 
@@ -293,7 +299,7 @@ def merge_code_fragments(
     A region is "mergeable" if:
     - Its type is "CODE", OR
     - It is a TEXT/FIGURE region whose text is identified as a code fragment
-      by is_code_fragment()
+      by is_code_fragment() AND its bbox meets minimum size requirements
 
     A non-mergeable region breaks the merge chain.
     Merged bbox is the bounding rectangle of all merged regions.
@@ -302,6 +308,8 @@ def merge_code_fragments(
         regions: List of region dicts with keys: type, label, bbox, confidence, text
         gap_threshold: Maximum vertical gap (px) between adjacent mergeable regions
                        to allow merging. Default: 80. Uses strict less-than (<).
+        min_region_width: Minimum width for fragment regions to be mergeable.
+        min_region_height: Minimum height for fragment regions to be mergeable.
 
     Returns:
         New list of region dicts. Input list and input dicts are not modified.
@@ -318,12 +326,25 @@ def merge_code_fragments(
             return True
         return is_code_fragment(region.get("text", ""))
 
-    def _merge_group(group: list[dict]) -> dict:
-        """Merge a group of regions into a single CODE region (bounding rect)."""
+    def _merge_group(group: list[dict]) -> dict | list[dict]:
+        """Merge a group of regions into a single CODE region (bounding rect).
+
+        If the group contains no original CODE region and the merged bbox
+        is too small, return the original regions unchanged (as a list).
+        """
         x1 = min(r["bbox"][0] for r in group)
         y1 = min(r["bbox"][1] for r in group)
         x2 = max(r["bbox"][2] for r in group)
         y2 = max(r["bbox"][3] for r in group)
+
+        has_real_code = any(r["type"] == "CODE" for r in group)
+        merged_w = x2 - x1
+        merged_h = y2 - y1
+
+        # Fragment-only groups that are too small stay as original regions
+        if not has_real_code and (merged_w < min_region_width or merged_h < min_region_height):
+            return [dict(r) for r in group]
+
         return {
             "type": "CODE",
             "label": "code",
@@ -363,7 +384,11 @@ def merge_code_fragments(
             j += 1
 
         # Emit merged region (or single region as new dict)
-        result.append(_merge_group(merge_group))
+        merged = _merge_group(merge_group)
+        if isinstance(merged, list):
+            result.extend(merged)
+        else:
+            result.append(merged)
         i = j
 
     return result

--- a/src/layout/detector.py
+++ b/src/layout/detector.py
@@ -58,10 +58,15 @@ def paragraphs_to_layout(
         Layout dict with regions list
     """
     from src.layout.code_detector import (
+        _DEFAULT_CODE_DETECTION_CONFIG,
         detect_code_by_text,
         detect_gray_background,
         merge_code_fragments,
     )
+
+    # Extract min region size config once
+    cfg_min_w = _DEFAULT_CODE_DETECTION_CONFIG["min_region_width"]
+    cfg_min_h = _DEFAULT_CODE_DETECTION_CONFIG["min_region_height"]
 
     regions = []
 
@@ -84,10 +89,12 @@ def paragraphs_to_layout(
             x1, y1, x2, y2 = bbox
             width = x2 - x1
             height = y2 - y1
-            # Skip aspect ratio filter: wide strips (width/height > 8.0) stay TEXT
-            if height > 0 and (width / height) <= 8.0:
-                if detect_gray_background(cv_img, bbox):
-                    region_type = "CODE"
+            # Skip small regions: too small to be a meaningful code block
+            if width >= cfg_min_w and height >= cfg_min_h:
+                # Skip aspect ratio filter: wide strips (width/height > 8.0) stay TEXT
+                if height > 0 and (width / height) <= 8.0:
+                    if detect_gray_background(cv_img, bbox):
+                        region_type = "CODE"
 
         # Text analysis: only for TEXT regions (not TITLE, not already CODE)
         if region_type == "TEXT":
@@ -140,7 +147,11 @@ def paragraphs_to_layout(
             )
 
     # Merge adjacent CODE and code-fragment regions
-    merged_regions = merge_code_fragments(regions)
+    merged_regions = merge_code_fragments(
+        regions,
+        min_region_width=cfg_min_w,
+        min_region_height=cfg_min_h,
+    )
 
     return {
         "regions": merged_regions,

--- a/tests/book_converter/test_code_block.py
+++ b/tests/book_converter/test_code_block.py
@@ -190,12 +190,13 @@ code block 2
         assert code_blocks[1].text == "code block 2"
 
     def test_code_block_not_merged_with_paragraph(self, tmp_path: Path):
+        # Must contain code indicators to survive filter_code_block
         md_content = """
 --- page_0001 ---
 
 paragraph before
 ```
-code here
+def hello(): pass
 ```
 paragraph after
 """
@@ -212,4 +213,4 @@ paragraph after
         assert len(code_blocks) == 1
         assert "paragraph before" in paragraphs[0].text
         assert "paragraph after" in paragraphs[1].text
-        assert code_blocks[0].text == "code here"
+        assert code_blocks[0].text == "def hello(): pass"

--- a/tests/book_converter/test_code_block_filter.py
+++ b/tests/book_converter/test_code_block_filter.py
@@ -1,0 +1,221 @@
+"""Tests for code block false-positive filtering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.book_converter.code_block_filter import (
+    _has_code_indicators,
+    _japanese_ratio,
+    filter_code_block,
+)
+from src.book_converter.models import CodeBlock, Paragraph
+from src.book_converter.parser.page import parse_pages_with_errors
+
+
+class TestHasCodeIndicators:
+    """Test code indicator detection."""
+
+    def test_python_code(self):
+        assert _has_code_indicators("def foo(): return 42") is True
+
+    def test_java_code(self):
+        assert _has_code_indicators("public void main(String[] args) {") is True
+
+    def test_pure_japanese(self):
+        assert _has_code_indicators("日本語のテキストです") is False
+
+    def test_isbn_reference(self):
+        assert _has_code_indicators("ISBN978-4-274-05019-0") is False
+
+    def test_braces_and_symbols(self):
+        assert _has_code_indicators("if (x > 0) { return x; }") is True
+
+    def test_empty(self):
+        assert _has_code_indicators("") is False
+
+    def test_short_number(self):
+        assert _has_code_indicators("3") is False
+
+    def test_arrow_operator(self):
+        assert _has_code_indicators("x => x + 1") is True
+
+
+class TestJapaneseRatio:
+    """Test Japanese character ratio calculation."""
+
+    def test_pure_japanese(self):
+        ratio = _japanese_ratio("日本語テスト")
+        assert ratio > 0.9
+
+    def test_pure_english(self):
+        ratio = _japanese_ratio("hello world")
+        assert ratio == 0.0
+
+    def test_mixed(self):
+        # "コード code" = 3 Japanese + 1 space + 4 English = ratio 3/8
+        ratio = _japanese_ratio("コードcode")
+        assert 0.3 < ratio < 0.5
+
+    def test_empty(self):
+        assert _japanese_ratio("") == 0.0
+
+
+class TestFilterCodeBlock:
+    """Test code block filtering logic."""
+
+    def test_empty_block_removed(self):
+        block = CodeBlock(text="")
+        assert filter_code_block(block) is None
+
+    def test_whitespace_only_removed(self):
+        block = CodeBlock(text="   \n  \n  ")
+        assert filter_code_block(block) is None
+
+    def test_short_non_code_demoted(self):
+        block = CodeBlock(text="3")
+        result = filter_code_block(block)
+        assert isinstance(result, Paragraph)
+        assert result.text == "3"
+
+    def test_short_code_kept(self):
+        block = CodeBlock(text="x = 1;")
+        result = filter_code_block(block)
+        # Has code indicators (=, ;), so kept as CodeBlock
+        assert isinstance(result, CodeBlock)
+
+    def test_japanese_book_reference_demoted(self):
+        text = "夫、平澤 章、梅澤真史 訳/オーム社/ ISBN978-4-274-05019-0)"
+        block = CodeBlock(text=text)
+        result = filter_code_block(block)
+        assert isinstance(result, Paragraph)
+
+    def test_japanese_prose_demoted(self):
+        text = "クラス名、ドキュメント、任意のパブリック関数はすべて、パブリックAPIの一部である"
+        block = CodeBlock(text=text)
+        result = filter_code_block(block)
+        assert isinstance(result, Paragraph)
+
+    def test_real_code_kept(self):
+        text = 'def hello():\n    print("world")\n    return True'
+        block = CodeBlock(text=text, language="python")
+        result = filter_code_block(block)
+        assert isinstance(result, CodeBlock)
+        assert result.text == text
+
+    def test_code_with_japanese_comments_kept(self):
+        text = "// 正しく設定が読み込まれたらtrueを返す\nBoolean loadSettings(File location) { ... }"
+        block = CodeBlock(text=text)
+        result = filter_code_block(block)
+        assert isinstance(result, CodeBlock)
+
+    def test_java_interface_kept(self):
+        text = "interface TextImportanceScorer {\nBoolean isImportant(String text);\n}"
+        block = CodeBlock(text=text)
+        result = filter_code_block(block)
+        assert isinstance(result, CodeBlock)
+
+    def test_single_brace_demoted(self):
+        block = CodeBlock(text="}")
+        result = filter_code_block(block)
+        # Short text with symbol - has code indicators but under length threshold
+        # '}' has symbol ratio > 0.05, so it IS a code indicator.
+        # But it's only 1 char, very short. Let's check what actually happens.
+        # len("}") = 1, symbol_count = 1, ratio = 1.0 > 0.05 → has_code_indicators = True
+        # len < 10 but has_code_indicators → kept as CodeBlock
+        assert isinstance(result, CodeBlock)
+
+    def test_kanji_word_demoted(self):
+        block = CodeBlock(text="可変")
+        result = filter_code_block(block)
+        assert isinstance(result, Paragraph)
+
+    def test_mixed_code_with_listing_header_kept(self):
+        text = (
+            "リスト2.6 インターフェイスと実装\n\ninterface TextImportanceScorer {\nBoolean isImportant(String text);\n}"
+        )
+        block = CodeBlock(text=text)
+        result = filter_code_block(block)
+        assert isinstance(result, CodeBlock)
+
+
+class TestFilterIntegration:
+    """Test code block filtering in full page pipeline."""
+
+    def test_empty_code_block_removed(self, tmp_path: Path):
+        md_content = """
+--- page_0001 ---
+
+Some text.
+
+```
+```
+
+More text.
+"""
+        md_file = tmp_path / "book.md"
+        md_file.write_text(md_content)
+
+        pages, _, _ = parse_pages_with_errors(md_file)
+        elements = pages[0].content.elements
+        code_blocks = [e for e in elements if isinstance(e, CodeBlock)]
+        assert len(code_blocks) == 0
+
+    def test_short_non_code_becomes_paragraph(self, tmp_path: Path):
+        md_content = """
+--- page_0001 ---
+
+Some text.
+
+```
+3
+```
+
+More text.
+"""
+        md_file = tmp_path / "book.md"
+        md_file.write_text(md_content)
+
+        pages, _, _ = parse_pages_with_errors(md_file)
+        elements = pages[0].content.elements
+        code_blocks = [e for e in elements if isinstance(e, CodeBlock)]
+        paragraphs = [e for e in elements if isinstance(e, Paragraph)]
+        assert len(code_blocks) == 0
+        # "3" should become a paragraph
+        assert any("3" in p.text for p in paragraphs)
+
+    def test_real_code_preserved(self, tmp_path: Path):
+        md_content = """
+--- page_0001 ---
+
+```python
+def hello():
+    return "world"
+```
+"""
+        md_file = tmp_path / "book.md"
+        md_file.write_text(md_content)
+
+        pages, _, _ = parse_pages_with_errors(md_file)
+        elements = pages[0].content.elements
+        code_blocks = [e for e in elements if isinstance(e, CodeBlock)]
+        assert len(code_blocks) == 1
+        assert code_blocks[0].language == "python"
+
+    def test_japanese_prose_becomes_paragraph(self, tmp_path: Path):
+        md_content = """
+--- page_0001 ---
+
+```
+クラス名、ドキュメント、任意のパブリック関数はすべて、パブリックAPIの一部である
+```
+"""
+        md_file = tmp_path / "book.md"
+        md_file.write_text(md_content)
+
+        pages, _, _ = parse_pages_with_errors(md_file)
+        elements = pages[0].content.elements
+        code_blocks = [e for e in elements if isinstance(e, CodeBlock)]
+        paragraphs = [e for e in elements if isinstance(e, Paragraph)]
+        assert len(code_blocks) == 0
+        assert len(paragraphs) >= 1

--- a/tests/test_code_detector.py
+++ b/tests/test_code_detector.py
@@ -480,6 +480,111 @@ class TestParagraphsToLayoutIntegration:
 
 
 # ============================================================
+# T014a: Small region size filtering
+# ============================================================
+
+
+class TestParagraphsToLayoutMinRegionSize:
+    """Small regions should NOT be detected as CODE via gray background."""
+
+    def test_tiny_region_stays_text(self) -> None:
+        """Region smaller than min_region_width/height stays TEXT even if gray."""
+        from src.layout.detector import paragraphs_to_layout
+
+        # 20x30 pixel region - too small
+        paragraph = make_paragraph_mock(
+            box=[100, 100, 120, 130],
+            role="plain text",
+            contents="3",
+        )
+
+        gray_img = make_solid_image([128, 128, 128], height=200, width=200)
+
+        result = paragraphs_to_layout(
+            [paragraph],
+            [],
+            (200, 200),
+            cv_img=gray_img,
+        )
+
+        regions = result["regions"]
+        assert len(regions) == 1
+        assert regions[0]["type"] == "TEXT", "Tiny gray region should stay TEXT"
+
+    def test_narrow_region_stays_text(self) -> None:
+        """Region narrower than min_region_width stays TEXT even if gray."""
+        from src.layout.detector import paragraphs_to_layout
+
+        # 50x100 pixel region - too narrow
+        paragraph = make_paragraph_mock(
+            box=[100, 100, 150, 200],
+            role="plain text",
+            contents="code?",
+        )
+
+        gray_img = make_solid_image([128, 128, 128], height=300, width=300)
+
+        result = paragraphs_to_layout(
+            [paragraph],
+            [],
+            (300, 300),
+            cv_img=gray_img,
+        )
+
+        regions = result["regions"]
+        assert len(regions) == 1
+        assert regions[0]["type"] == "TEXT", "Narrow gray region should stay TEXT"
+
+    def test_short_region_stays_text(self) -> None:
+        """Region shorter than min_region_height stays TEXT even if gray."""
+        from src.layout.detector import paragraphs_to_layout
+
+        # 200x30 pixel region - too short
+        paragraph = make_paragraph_mock(
+            box=[10, 10, 210, 40],
+            role="plain text",
+            contents="single line",
+        )
+
+        gray_img = make_solid_image([128, 128, 128], height=100, width=300)
+
+        result = paragraphs_to_layout(
+            [paragraph],
+            [],
+            (300, 100),
+            cv_img=gray_img,
+        )
+
+        regions = result["regions"]
+        assert len(regions) == 1
+        assert regions[0]["type"] == "TEXT", "Short gray region should stay TEXT"
+
+    def test_large_enough_region_becomes_code(self) -> None:
+        """Region meeting minimum size becomes CODE when gray."""
+        from src.layout.detector import paragraphs_to_layout
+
+        # 200x100 pixel region - large enough
+        paragraph = make_paragraph_mock(
+            box=[10, 10, 210, 110],
+            role="plain text",
+            contents="some text",
+        )
+
+        gray_img = make_solid_image([128, 128, 128], height=200, width=300)
+
+        result = paragraphs_to_layout(
+            [paragraph],
+            [],
+            (300, 200),
+            cv_img=gray_img,
+        )
+
+        regions = result["regions"]
+        assert len(regions) == 1
+        assert regions[0]["type"] == "CODE", "Large enough gray region should become CODE"
+
+
+# ============================================================
 # T014: paragraphs_to_layout() backward compatibility test
 # ============================================================
 
@@ -2134,3 +2239,13 @@ class TestLoadCodeDetectionConfig:
         assert isinstance(config["symbol_ratio_threshold"], float)
         assert isinstance(config["keyword_threshold"], int)
         assert isinstance(config["fragment_gap_threshold"], int)
+        assert isinstance(config["min_region_width"], int)
+        assert isinstance(config["min_region_height"], int)
+
+    def test_min_region_defaults(self) -> None:
+        """Default min_region_width/height should be present."""
+        from src.layout.code_detector import load_code_detection_config
+
+        config = load_code_detection_config()
+        assert config["min_region_width"] == 100
+        assert config["min_region_height"] == 60


### PR DESCRIPTION
## Summary

- code_detector に最小リージョンサイズ制約（100x60px）を追加し、小さすぎるリージョンの灰色背景検出をスキップ
- converter にコードブロックフィルタを追加し、空・短文・高日本語比率のコードブロックを除去/降格
- 実データ（848d29b0988c09ae）で CODE リージョン 628→418、コードブロック 567→186 に削減

## Test plan

- [x] 最小リージョンサイズのテスト（tiny/narrow/short/large enough）
- [x] コードブロックフィルタのユニットテスト（空、短文、日本語、実コード）
- [x] 統合テスト（パイプライン全体でのフィルタ動作）
- [x] 既存テスト全件パス（1658 passed）
- [x] ruff / pylint クリーン

Closes #53