### PR TITLE
feat: BOOK_DIR 連携・XSD スキーマ・XML バリデータ追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ run: setup ## Run full pipeline for a video (VIDEO required, OUTPUT/LIMIT option
 	@$(MAKE) --no-print-directory consolidate HASHDIR="$(HASHDIR)" LIMIT="$(LIMIT)"
 	@echo "=== Step 6: Convert to XML ==="
 	@$(MAKE) --no-print-directory converter HASHDIR="$(HASHDIR)"
+	@echo "=== Step 7: Validate XML ==="
+	@$(MAKE) --no-print-directory validate-xml HASHDIR="$(HASHDIR)"
 	@echo "=== Done: $(HASHDIR)/book.xml ==="
 	@echo ""
 	@echo "To use with text-reading-with-llm:"

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,9 @@ run: setup ## Run full pipeline for a video (VIDEO required, OUTPUT/LIMIT option
 	@echo "=== Step 6: Convert to XML ==="
 	@$(MAKE) --no-print-directory converter HASHDIR="$(HASHDIR)"
 	@echo "=== Done: $(HASHDIR)/book.xml ==="
+	@echo ""
+	@echo "To use with text-reading-with-llm:"
+	@echo "  export BOOK_DIR=$(abspath $(HASHDIR))"
 
 # === Preview ===
 .PHONY: preview-extract preview-trim-grid
@@ -151,6 +154,13 @@ normalize-toc: setup ## Normalize OCR errors in TOC entries (requires HASHDIR, o
 normalize-headings: setup ## Normalize headings to match TOC (requires HASHDIR, optional APPLY=1)
 	@test -n "$(HASHDIR)" || { echo "Error: HASHDIR required. Usage: make normalize-headings HASHDIR=output/<hash> [APPLY=1]"; exit 1; }
 	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.cli.normalize_headings normalize "$(HASHDIR)/book.md" $(if $(APPLY),--apply)
+
+# === Validation ===
+.PHONY: validate-xml
+
+validate-xml: setup ## Validate book.xml against XSD schema (requires HASHDIR)
+	@test -n "$(HASHDIR)" || { echo "Error: HASHDIR required. Usage: make validate-xml HASHDIR=output/<hash>"; exit 1; }
+	PYTHONPATH=$(CURDIR) $(PYTHON) -m src.cli.validate_xml "$(HASHDIR)/book.xml"
 
 # === Testing ===
 .PHONY: test test-all test-slow test-cov test-cov-all

--- a/docs/book-xml-schema.md
+++ b/docs/book-xml-schema.md
@@ -1,0 +1,149 @@
+# book.xml Schema Reference
+
+**Version**: 2.1.0
+**Last Updated**: 2026-03-25
+
+book.xml は ebook-ocr パイプラインの最終出力であり、text-reading-with-llm の入力として使用される。
+
+## スキーマ検証
+
+```bash
+# XSD によるプログラム的検証
+make validate-xml HASHDIR=output/<hash>
+```
+
+XSD 定義: [`docs/book.xsd`](book.xsd)
+
+## 出力形式
+
+| 形式 | フラグ | 説明 |
+|------|--------|------|
+| Legacy (page-based) | なし（デフォルト） | フラットなページ構造 |
+| Modern (chapter-based) | `--group-pages` | 章・セクションの階層構造 |
+
+現在のパイプライン (`make run`) は `--group-pages` を使用し、Modern 形式を出力する。
+
+## ルート構造
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<book>
+  <metadata>...</metadata>
+  <toc>...</toc>              <!-- optional -->
+  <front-matter>...</front-matter>  <!-- optional, Modern のみ -->
+  <chapter>...</chapter>      <!-- Modern 形式 -->
+  <page>...</page>            <!-- Legacy 形式 -->
+</book>
+```
+
+## 要素定義
+
+### `<metadata>`
+
+```xml
+<metadata>
+  <title>書籍タイトル</title>
+  <isbn>1234567890123</isbn>              <!-- optional -->
+  <sourceFormat>markdown</sourceFormat>   <!-- optional -->
+  <conversionDate>2026-03-25</conversionDate>  <!-- optional -->
+</metadata>
+```
+
+### `<toc>` (目次)
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| begin | string | No | TOC 開始ページ番号 |
+| end | string | No | TOC 終了ページ番号 |
+
+#### `<entry>`
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| level | positiveInteger | Yes | 階層レベル (1-5) |
+| number | string | No | エントリ番号 |
+| title | string | Yes | タイトル |
+| page | string | No | ページ番号 |
+
+---
+
+## Modern 形式 (chapter-based)
+
+### `<front-matter>`
+
+TOC より前のコンテンツ。子要素: heading, paragraph, list, figure, code。
+
+### `<chapter>`
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| number | string | No | 章番号 |
+| title | string | Yes | 章タイトル |
+
+子要素: heading, paragraph, list, figure, code, section。
+
+### `<section>`
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| number | string | No | セクション番号 |
+| title | string | Yes | セクションタイトル |
+
+子要素: heading, paragraph, list, figure, code。
+
+---
+
+## Legacy 形式 (page-based)
+
+### `<page>`
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| number | string | Yes | ページ番号 |
+| sourceFile | string | Yes | ソース画像ファイル名 |
+| continued | string | No | 前ページからの継続 |
+| type | string | No | "normal", "cover", "colophon", "toc" |
+
+子要素: pageAnnouncement, figure, content, pageMetadata。
+
+---
+
+## コンテンツ要素 (共通)
+
+### `<heading>`
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| level | positiveInteger | 見出しレベル (Legacy のみ) |
+| readAloud | string | 読み上げ対象か |
+
+テキスト内の `**太字**` は `<em>太字</em>` に変換される。
+
+### `<paragraph>`
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| readAloud | string | "false" のみ出力 (skip 区間) |
+
+### `<list>`
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| readAloud | string | "false" のみ出力 |
+| type | string | "unordered" or "ordered" |
+
+### `<code>`
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| readAloud | string | 常に "false" |
+| language | string | 言語ヒント |
+
+### `<figure>`
+
+Modern (self-closing): `path` (required), `caption`, `marker` 属性。
+Legacy (子要素あり): `file`, `caption`, `description` 子要素。
+
+### `<em>`
+
+heading, paragraph, item 内のインライン強調要素。

--- a/docs/book.xsd
+++ b/docs/book.xsd
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- ============================================================ -->
+  <!-- Root Element                                                  -->
+  <!-- ============================================================ -->
+
+  <xs:element name="book">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="metadata" />
+        <xs:element ref="toc" minOccurs="0" />
+        <!-- Modern format: chapter-based -->
+        <xs:element ref="front-matter" minOccurs="0" />
+        <xs:element ref="chapter" minOccurs="0" maxOccurs="unbounded" />
+        <!-- Legacy format: page-based -->
+        <xs:element ref="page" minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- ============================================================ -->
+  <!-- Metadata                                                      -->
+  <!-- ============================================================ -->
+
+  <xs:element name="metadata">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="title" type="xs:string" />
+        <xs:element name="isbn" type="xs:string" minOccurs="0" />
+        <xs:element name="sourceFormat" type="xs:string" minOccurs="0" />
+        <xs:element name="conversionDate" type="xs:string" minOccurs="0" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- ============================================================ -->
+  <!-- Table of Contents                                             -->
+  <!-- ============================================================ -->
+
+  <xs:element name="toc">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="entry" minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="begin" type="xs:string" />
+      <xs:attribute name="end" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="entry">
+    <xs:complexType>
+      <xs:attribute name="level" type="xs:positiveInteger" use="required" />
+      <xs:attribute name="number" type="xs:string" />
+      <xs:attribute name="title" type="xs:string" use="required" />
+      <xs:attribute name="page" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <!-- ============================================================ -->
+  <!-- Modern Format: Chapter / Section                              -->
+  <!-- ============================================================ -->
+
+  <xs:element name="front-matter">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="heading" />
+        <xs:element ref="paragraph" />
+        <xs:element ref="list" />
+        <xs:element ref="figure" />
+        <xs:element ref="code" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="chapter">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="heading" />
+        <xs:element ref="paragraph" />
+        <xs:element ref="list" />
+        <xs:element ref="figure" />
+        <xs:element ref="code" />
+        <xs:element ref="section" />
+      </xs:choice>
+      <xs:attribute name="number" type="xs:string" />
+      <xs:attribute name="title" type="xs:string" use="required" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="section">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="heading" />
+        <xs:element ref="paragraph" />
+        <xs:element ref="list" />
+        <xs:element ref="figure" />
+        <xs:element ref="code" />
+      </xs:choice>
+      <xs:attribute name="number" type="xs:string" />
+      <xs:attribute name="title" type="xs:string" use="required" />
+    </xs:complexType>
+  </xs:element>
+
+  <!-- ============================================================ -->
+  <!-- Content Elements                                              -->
+  <!-- ============================================================ -->
+
+  <xs:complexType name="textWithEmphasis" mixed="true">
+    <xs:sequence>
+      <xs:element ref="em" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:element name="heading">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element ref="em" minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="level" type="xs:positiveInteger" />
+      <xs:attribute name="readAloud" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="paragraph">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element ref="em" minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="readAloud" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="list">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="item" minOccurs="1" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="readAloud" type="xs:string" />
+      <xs:attribute name="type" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="item">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element ref="em" minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="figure">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="file" type="xs:string" minOccurs="0" />
+        <xs:element name="caption" minOccurs="0">
+          <xs:complexType mixed="true">
+            <xs:attribute name="readAloud" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="description" type="xs:string" minOccurs="0" />
+      </xs:sequence>
+      <xs:attribute name="path" type="xs:string" />
+      <xs:attribute name="caption" type="xs:string" />
+      <xs:attribute name="marker" type="xs:string" />
+      <xs:attribute name="readAloud" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="code">
+    <xs:complexType mixed="true">
+      <xs:attribute name="readAloud" type="xs:string" />
+      <xs:attribute name="language" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="em" type="xs:string" />
+
+  <!-- ============================================================ -->
+  <!-- Legacy Format: Page-based                                     -->
+  <!-- ============================================================ -->
+
+  <xs:element name="page">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="pageAnnouncement" minOccurs="0" />
+        <xs:element ref="figure" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="content" minOccurs="0" />
+        <xs:element ref="pageMetadata" minOccurs="0" />
+      </xs:sequence>
+      <xs:attribute name="number" type="xs:string" use="required" />
+      <xs:attribute name="sourceFile" type="xs:string" use="required" />
+      <xs:attribute name="continued" type="xs:string" />
+      <xs:attribute name="type" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="pageAnnouncement">
+    <xs:complexType mixed="true">
+      <xs:attribute name="format" type="xs:string" />
+      <xs:attribute name="readAloud" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="content">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="heading" />
+        <xs:element ref="paragraph" />
+        <xs:element ref="list" />
+        <xs:element ref="code" />
+      </xs:choice>
+      <xs:attribute name="readAloud" type="xs:string" />
+      <xs:attribute name="continued" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="pageMetadata">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element ref="em" minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="type" type="xs:string" />
+      <xs:attribute name="readAloud" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytesseract>=0.3.10
 yomitoku>=0.10.0
 pylint>=3.0.0
 rich
+lxml

--- a/src/cli/validate_xml.py
+++ b/src/cli/validate_xml.py
@@ -1,0 +1,91 @@
+"""Validate book.xml against XSD schema using lxml."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from lxml import etree
+
+from src.logging_config import setup_logging
+
+logger = logging.getLogger(__name__)
+
+# XSD path relative to project root
+DEFAULT_XSD_PATH = Path(__file__).resolve().parent.parent.parent / "docs" / "book.xsd"
+
+
+def validate_xml(xml_path: Path, xsd_path: Path) -> list[str]:
+    """Validate an XML file against an XSD schema.
+
+    Args:
+        xml_path: Path to the XML file.
+        xsd_path: Path to the XSD schema file.
+
+    Returns:
+        List of error messages. Empty if valid.
+
+    Raises:
+        FileNotFoundError: If xml_path or xsd_path does not exist.
+        etree.XMLSyntaxError: If the XML is not well-formed.
+    """
+    if not xml_path.exists():
+        raise FileNotFoundError(f"XML file not found: {xml_path}")
+    if not xsd_path.exists():
+        raise FileNotFoundError(f"XSD file not found: {xsd_path}")
+
+    xsd_doc = etree.parse(str(xsd_path))
+    schema = etree.XMLSchema(xsd_doc)
+
+    xml_doc = etree.parse(str(xml_path))
+    is_valid = schema.validate(xml_doc)
+
+    if is_valid:
+        return []
+
+    return [str(err) for err in schema.error_log]
+
+
+def main() -> None:
+    """CLI entry point for XML validation."""
+    setup_logging()
+
+    parser = argparse.ArgumentParser(
+        description="Validate book.xml against XSD schema",
+    )
+    parser.add_argument(
+        "xml_path",
+        type=Path,
+        help="Path to the book.xml file",
+    )
+    parser.add_argument(
+        "--xsd",
+        type=Path,
+        default=DEFAULT_XSD_PATH,
+        help=f"Path to XSD schema (default: {DEFAULT_XSD_PATH})",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        errors = validate_xml(args.xml_path, args.xsd)
+    except FileNotFoundError as e:
+        logger.error(str(e))
+        sys.exit(1)
+    except etree.XMLSyntaxError as e:
+        logger.error("XML is not well-formed: %s", e)
+        sys.exit(1)
+
+    if errors:
+        logger.error("Validation FAILED with %d error(s):", len(errors))
+        for err in errors:
+            logger.error("  %s", err)
+        sys.exit(1)
+
+    logger.info("Validation passed: %s", args.xml_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/test_validate_xml.py
+++ b/tests/cli/test_validate_xml.py
@@ -1,0 +1,77 @@
+"""Tests for src.cli.validate_xml module."""
+
+from pathlib import Path
+
+import pytest
+
+from src.cli.validate_xml import DEFAULT_XSD_PATH, validate_xml
+
+FIXTURE_DIR = Path(__file__).resolve().parent.parent / "book_converter" / "fixtures"
+
+
+class TestValidateXml:
+    """Tests for validate_xml function."""
+
+    def test_valid_fixture_passes(self) -> None:
+        xml_path = FIXTURE_DIR / "expected_book.xml"
+        errors = validate_xml(xml_path, DEFAULT_XSD_PATH)
+        assert errors == []
+
+    def test_invalid_xml_returns_errors(self, tmp_path: Path) -> None:
+        xml_path = tmp_path / "bad.xml"
+        xml_path.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?><book><unknown_tag/></book>',
+            encoding="utf-8",
+        )
+        errors = validate_xml(xml_path, DEFAULT_XSD_PATH)
+        assert len(errors) > 0
+        assert "unknown_tag" in errors[0]
+
+    def test_missing_required_attribute(self, tmp_path: Path) -> None:
+        xml_path = tmp_path / "missing_attr.xml"
+        xml_path.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<book><metadata><title>Test</title></metadata>"
+            '<page number="1"><content/></page></book>',
+            encoding="utf-8",
+        )
+        errors = validate_xml(xml_path, DEFAULT_XSD_PATH)
+        assert len(errors) > 0
+        assert "sourceFile" in errors[0]
+
+    def test_xml_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="XML file not found"):
+            validate_xml(tmp_path / "nonexistent.xml", DEFAULT_XSD_PATH)
+
+    def test_xsd_file_not_found(self, tmp_path: Path) -> None:
+        xml_path = FIXTURE_DIR / "expected_book.xml"
+        with pytest.raises(FileNotFoundError, match="XSD file not found"):
+            validate_xml(xml_path, tmp_path / "nonexistent.xsd")
+
+    def test_malformed_xml(self, tmp_path: Path) -> None:
+        xml_path = tmp_path / "malformed.xml"
+        xml_path.write_text("<book><unclosed>", encoding="utf-8")
+        from lxml import etree
+
+        with pytest.raises(etree.XMLSyntaxError):
+            validate_xml(xml_path, DEFAULT_XSD_PATH)
+
+    def test_valid_modern_format(self, tmp_path: Path) -> None:
+        xml_path = tmp_path / "modern.xml"
+        xml_path.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<book>"
+            "<metadata><title>Test</title></metadata>"
+            '<chapter title="Ch1">'
+            '<section title="S1">'
+            "<paragraph>text</paragraph>"
+            "</section>"
+            "</chapter>"
+            "</book>",
+            encoding="utf-8",
+        )
+        errors = validate_xml(xml_path, DEFAULT_XSD_PATH)
+        assert errors == []
+
+    def test_xsd_file_exists(self) -> None:
+        assert DEFAULT_XSD_PATH.exists(), f"XSD file missing: {DEFAULT_XSD_PATH}"


### PR DESCRIPTION
## Summary

- パイプライン完了時に `export BOOK_DIR=<絶対パス>` を表示し、text-reading-with-llm との連携を容易にする
- `docs/book.xsd` に W3C XML Schema を定義（Legacy page-based / Modern chapter-based 両形式対応）
- `src/cli/validate_xml.py` で lxml による XSD バリデーションを実装
- `make validate-xml HASHDIR=output/<hash>` で検証実行可能
- `docs/book-xml-schema.md` にスキーマリファレンスドキュメントを追加

## Test plan

- [x] `make test` 全テスト通過 (1659 passed)
- [x] `make lint` 通過
- [x] テストフィクスチャ (`expected_book.xml`) が XSD 検証を通過
- [x] 実際の book.xml が XSD 検証を通過
- [x] `make validate-xml` で正常に検証実行できることを確認
- [ ] `make run VIDEO=...` 実行後に `export BOOK_DIR=...` が表示されることを確認

Closes #63